### PR TITLE
Update nix to 0.9, support FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "0.8.2"
 libc = "0.2.22"
 fixedbitset = "0.1.6"
 num = "0.1.37"
-nix = "0.8.1"
+nix = "0.9.0"
 
 [features]
 unstable = []

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Nice(r) access to `evdev` devices.
 What is `evdev`?
 ===================
 
-`evdev` is the Linux kernel's generic input interface. This crate exposes
-access to these sorts of input devices. There is some trickery involved, so
-please read the crate documentation.
+`evdev` is the Linux kernel's generic input interface, also implemented by other
+kernels such as FreeBSD.
+
+This crate exposes access to these sorts of input devices. There is some trickery
+involved, so please read the crate documentation.
 
 What does this library support?
 ===============================
 
 This library exposes raw evdev events, but uses the Rust `Iterator` trait to
 do so, and will handle `SYN_DROPPED` events properly for the client. I try to
-match [libevdev](http://www.freedesktop.org/software/libevdev/doc/latest/)
+match [libevdev](https://www.freedesktop.org/software/libevdev/doc/latest/)
 closely, where possible.
 
 Writing to devices is not yet supported (eg, turning LEDs on).
@@ -33,5 +35,5 @@ Example
 =======
 
 See <examples/evtest.rs> for an example of using this library (which roughly
-corresponds to the userspace [evtest](http://cgit.freedesktop.org/evtest/)
+corresponds to the userspace [evtest](https://cgit.freedesktop.org/evtest/)
 tool.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ use std::path::Path;
 use std::ffi::{CString, CStr};
 use std::mem::{size_of, transmute};
 use fixedbitset::FixedBitSet;
-use num::traits::WrappingSub;
 
 use nix::Error;
 
@@ -680,7 +679,7 @@ impl Device {
     pub fn open(path: &AsRef<Path>) -> Result<Device, Error> {
         let cstr = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(s) => s,
-            Err(e) => return Err(Error::InvalidPath),
+            Err(_) => return Err(Error::InvalidPath),
         };
         // FIXME: only need for writing is for setting LED values. re-evaluate always using RDWR
         // later.
@@ -919,7 +918,7 @@ impl Device {
     }
 
     fn fill_events(&mut self) -> Result<(), Error> {
-        let mut buf = &mut self.pending_events;
+        let buf = &mut self.pending_events;
         loop {
             buf.reserve(20);
             let pre_len = buf.len();

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -3,12 +3,12 @@ ioctl!(read eviocgid with b'E', 0x02; /*struct*/ input_id);
 ioctl!(read eviocgkeycode with b'E', 0x04; [::libc::c_uint; 2]);
 ioctl!(read eviocgrep with b'E', 0x03; [::libc::c_uint; 2]);
 ioctl!(read eviocgversion with b'E', 0x01; ::libc::c_int);
-ioctl!(write eviocrmff with b'E', 0x81; ::libc::c_int);
+ioctl!(write_int eviocrmff with b'E', 0x81);
 // ioctl!(read eviocgkeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
 // TODO #define EVIOCSFF _IOC ( _IOC_WRITE , 'E' , 0x80 , sizeof ( struct ff_effect ) )
-ioctl!(write eviocskeycode with b'E', 0x04; [::libc::c_uint; 2]);
-// ioctl!(write eviocskeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
-ioctl!(write eviocsrep with b'E', 0x03; [::libc::c_uint; 2]);
+ioctl!(write_ptr eviocskeycode with b'E', 0x04; [::libc::c_uint; 2]);
+// ioctl!(write_int eviocskeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
+ioctl!(write_ptr eviocsrep with b'E', 0x03; [::libc::c_uint; 2]);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -192,26 +192,26 @@ impl ::std::default::Default for ff_rumble_effect {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 
-ioctl!(read buf eviocgname with b'E', 0x06; u8);
-ioctl!(read buf eviocgphys with b'E', 0x07; u8);
-ioctl!(read buf eviocguniq with b'E', 0x08; u8);
-ioctl!(read buf eviocgprop with b'E', 0x09; u8);
-ioctl!(read buf eviocgmtslots with b'E', 0x0a; u8);
-ioctl!(read buf eviocgkey with b'E', 0x18; u8);
-ioctl!(read buf eviocgled with b'E', 0x19; u8);
-ioctl!(read buf eviocgsnd with b'E', 0x1a; u8);
-ioctl!(read buf eviocgsw with b'E', 0x1b; u8);
+ioctl!(read_buf eviocgname with b'E', 0x06; u8);
+ioctl!(read_buf eviocgphys with b'E', 0x07; u8);
+ioctl!(read_buf eviocguniq with b'E', 0x08; u8);
+ioctl!(read_buf eviocgprop with b'E', 0x09; u8);
+ioctl!(read_buf eviocgmtslots with b'E', 0x0a; u8);
+ioctl!(read_buf eviocgkey with b'E', 0x18; u8);
+ioctl!(read_buf eviocgled with b'E', 0x19; u8);
+ioctl!(read_buf eviocgsnd with b'E', 0x1a; u8);
+ioctl!(read_buf eviocgsw with b'E', 0x1b; u8);
 
-ioctl!(write eviocsff with b'E', 0x80; ff_effect);
-ioctl!(write eviocgrab with b'E', 0x90; ::libc::c_int);
-ioctl!(write eviocrevoke with b'E', 0x91; ::libc::c_int);
-ioctl!(write eviocsclockid with b'E', 0xa0; ::libc::c_int);
+ioctl!(write_ptr eviocsff with b'E', 0x80; ff_effect);
+ioctl!(write_int eviocgrab with b'E', 0x90);
+ioctl!(write_int eviocrevoke with b'E', 0x91);
+ioctl!(write_int eviocsclockid with b'E', 0xa0);
 
 pub unsafe fn eviocgbit(fd: ::libc::c_int, ev: u32, len: ::libc::c_int, buf: *mut u8) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::sys::ioctl::ioctl(fd, ior!(b'E', 0x20 + ev, len) as ::libc::c_ulong, buf))
+    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x20 + ev, len) as ::libc::c_ulong, buf))
 }
 
 pub unsafe fn eviocgabs(fd: ::libc::c_int, abs: u32, buf: *mut input_absinfo) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::sys::ioctl::ioctl(fd, ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_ulong, buf))
+    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_ulong, buf))
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -168,7 +168,6 @@ impl ::std::default::Default for ff_condition_effect {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[allow(raw_pointer_derive)]
 pub struct ff_periodic_effect {
     pub waveform: u16,
     pub period: u16,


### PR DESCRIPTION
nix 0.9's ioctl macro works with buffers now.

eviocgname/eviocgphys/eviocguniq do not return the number of bytes on FreeBSD, just zero. So let CStr handle the null termination.