### PR TITLE
Fix compile warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/cmr/evdev"
 documentation = "https://docs.rs/evdev"
 
 [dependencies]
-bitflags = "0.8.2"
+bitflags = "1.2.1"
 libc = "0.2.22"
 fixedbitset = "0.1.6"
 num = "0.1.37"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,229 +87,229 @@ macro_rules! do_ioctl_buf {
 
 bitflags! {
     /// Event types supported by the device.
-    pub flags Types: u32 {
+    pub struct Types: u32 {
         /// A bookkeeping event. Usually not important to applications.
-        const SYNCHRONIZATION = 1 << 0x00,
+        const SYNCHRONIZATION = 1 << 0x00;
         /// A key changed state. A key, or button, is usually a momentary switch (in the circuit sense). It has two
         /// states: down, or up. There are events for when keys are pressed (become down) and
         /// released (become up). There are also "key repeats", where multiple events are sent
         /// while a key is down.
-        const KEY = 1 << 0x01,
+        const KEY = 1 << 0x01;
         /// Movement on a relative axis. There is no absolute coordinate frame, just the fact that
         /// there was a change of a certain amount of units. Used for things like mouse movement or
         /// scroll wheels.
-        const RELATIVE = 1 << 0x02,
+        const RELATIVE = 1 << 0x02;
         /// Movement on an absolute axis. Used for things such as touch events and joysticks.
-        const ABSOLUTE = 1 << 0x03,
+        const ABSOLUTE = 1 << 0x03;
         /// Miscellaneous events that don't fall into other categories. I'm not quite sure when
         /// these happen or what they correspond to.
-        const MISC = 1 << 0x04,
+        const MISC = 1 << 0x04;
         /// Change in a switch value. Switches are boolean conditions and usually correspond to a
         /// toggle switch of some kind in hardware.
-        const SWITCH = 1 << 0x05,
+        const SWITCH = 1 << 0x05;
         /// An LED was toggled.
-        const LED = 1 << 0x11,
+        const LED = 1 << 0x11;
         /// A sound was made.
-        const SOUND = 1 << 0x12,
+        const SOUND = 1 << 0x12;
         /// There are no events of this type, to my knowledge, but represents metadata about key
         /// repeat configuration.
-        const REPEAT = 1 << 0x14,
+        const REPEAT = 1 << 0x14;
         /// I believe there are no events of this type, but rather this is used to represent that
         /// the device can create haptic effects.
-        const FORCEFEEDBACK = 1 << 0x15,
+        const FORCEFEEDBACK = 1 << 0x15;
         /// I think this is unused?
-        const POWER = 1 << 0x16,
+        const POWER = 1 << 0x16;
         /// A force feedback effect's state changed.
-        const FORCEFEEDBACKSTATUS = 1 << 0x17,
+        const FORCEFEEDBACKSTATUS = 1 << 0x17;
     }
 }
 
 bitflags! {
     /// Device properties.
-    pub flags Props: u32 {
+    pub struct Props: u32 {
         /// This input device needs a pointer ("cursor") for the user to know its state.
-        const POINTER = 1 << 0x00,
+        const POINTER = 1 << 0x00;
         /// "direct input devices", according to the header.
-        const DIRECT = 1 << 0x01,
+        const DIRECT = 1 << 0x01;
         /// "has button(s) under pad", according to the header.
-        const BUTTONPAD = 1 << 0x02,
+        const BUTTONPAD = 1 << 0x02;
         /// Touch rectangle only (I think this means that if there are multiple touches, then the
         /// bounding rectangle of all the touches is returned, not each touch).
-        const SEMI_MT = 1 << 0x03,
+        const SEMI_MT = 1 << 0x03;
         /// "softbuttons at top of pad", according to the header.
-        const TOPBUTTONPAD = 1 << 0x04,
+        const TOPBUTTONPAD = 1 << 0x04;
         /// Is a pointing stick ("clit mouse" etc, https://xkcd.com/243/)
-        const POINTING_STICK = 1 << 0x05,
+        const POINTING_STICK = 1 << 0x05;
         /// Has an accelerometer. Probably reports relative events in that case?
-        const ACCELEROMETER = 1 << 0x06
+        const ACCELEROMETER = 1 << 0x0;
     }
 }
 
 include!("scancodes.rs"); // it's a huge glob of text that I'm tired of skipping over.
 
 bitflags! {
-    pub flags RelativeAxis: u32 {
-        const REL_X = 1 << 0x00,
-        const REL_Y = 1 << 0x01,
-        const REL_Z = 1 << 0x02,
-        const REL_RX = 1 << 0x03,
-        const REL_RY = 1 << 0x04,
-        const REL_RZ = 1 << 0x05,
-        const REL_HWHEEL = 1 << 0x06,
-        const REL_DIAL = 1 << 0x07,
-        const REL_WHEEL = 1 << 0x08,
-        const REL_MISC = 1 << 0x09,
-        const REL_RESERVED = 1 << 0x0a,
-        const REL_WHEEL_HI_RES = 1 << 0x0b,
-        const REL_HWHEEL_HI_RES = 1 << 0x0c,
-        const REL_MAX = 1 << 0x0f,
+    pub struct RelativeAxis: u32 {
+        const REL_X = 1 << 0x00;
+        const REL_Y = 1 << 0x01;
+        const REL_Z = 1 << 0x02;
+        const REL_RX = 1 << 0x03;
+        const REL_RY = 1 << 0x04;
+        const REL_RZ = 1 << 0x05;
+        const REL_HWHEEL = 1 << 0x06;
+        const REL_DIAL = 1 << 0x07;
+        const REL_WHEEL = 1 << 0x08;
+        const REL_MISC = 1 << 0x09;
+        const REL_RESERVED = 1 << 0x0a;
+        const REL_WHEEL_HI_RES = 1 << 0x0b;
+        const REL_HWHEEL_HI_RES = 1 << 0x0c;
+        const REL_MAX = 1 << 0x0f;
     }
 }
 
 bitflags! {
-    pub flags AbsoluteAxis: u64 {
-        const ABS_X = 1 << 0x00,
-        const ABS_Y = 1 << 0x01,
-        const ABS_Z = 1 << 0x02,
-        const ABS_RX = 1 << 0x03,
-        const ABS_RY = 1 << 0x04,
-        const ABS_RZ = 1 << 0x05,
-        const ABS_THROTTLE = 1 << 0x06,
-        const ABS_RUDDER = 1 << 0x07,
-        const ABS_WHEEL = 1 << 0x08,
-        const ABS_GAS = 1 << 0x09,
-        const ABS_BRAKE = 1 << 0x0a,
-        const ABS_HAT0X = 1 << 0x10,
-        const ABS_HAT0Y = 1 << 0x11,
-        const ABS_HAT1X = 1 << 0x12,
-        const ABS_HAT1Y = 1 << 0x13,
-        const ABS_HAT2X = 1 << 0x14,
-        const ABS_HAT2Y = 1 << 0x15,
-        const ABS_HAT3X = 1 << 0x16,
-        const ABS_HAT3Y = 1 << 0x17,
-        const ABS_PRESSURE = 1 << 0x18,
-        const ABS_DISTANCE = 1 << 0x19,
-        const ABS_TILT_X = 1 << 0x1a,
-        const ABS_TILT_Y = 1 << 0x1b,
-        const ABS_TOOL_WIDTH = 1 << 0x1c,
-        const ABS_VOLUME = 1 << 0x20,
-        const ABS_MISC = 1 << 0x28,
+    pub struct AbsoluteAxis: u64 {
+        const ABS_X = 1 << 0x00;
+        const ABS_Y = 1 << 0x01;
+        const ABS_Z = 1 << 0x02;
+        const ABS_RX = 1 << 0x03;
+        const ABS_RY = 1 << 0x04;
+        const ABS_RZ = 1 << 0x05;
+        const ABS_THROTTLE = 1 << 0x06;
+        const ABS_RUDDER = 1 << 0x07;
+        const ABS_WHEEL = 1 << 0x08;
+        const ABS_GAS = 1 << 0x09;
+        const ABS_BRAKE = 1 << 0x0a;
+        const ABS_HAT0X = 1 << 0x10;
+        const ABS_HAT0Y = 1 << 0x11;
+        const ABS_HAT1X = 1 << 0x12;
+        const ABS_HAT1Y = 1 << 0x13;
+        const ABS_HAT2X = 1 << 0x14;
+        const ABS_HAT2Y = 1 << 0x15;
+        const ABS_HAT3X = 1 << 0x16;
+        const ABS_HAT3Y = 1 << 0x17;
+        const ABS_PRESSURE = 1 << 0x18;
+        const ABS_DISTANCE = 1 << 0x19;
+        const ABS_TILT_X = 1 << 0x1a;
+        const ABS_TILT_Y = 1 << 0x1b;
+        const ABS_TOOL_WIDTH = 1 << 0x1c;
+        const ABS_VOLUME = 1 << 0x20;
+        const ABS_MISC = 1 << 0x28;
         /// "MT slot being modified"
-        const ABS_MT_SLOT = 1 << 0x2f,
+        const ABS_MT_SLOT = 1 << 0x2f;
         /// "Major axis of touching ellipse"
-        const ABS_MT_TOUCH_MAJOR = 1 << 0x30,
+        const ABS_MT_TOUCH_MAJOR = 1 << 0x30;
         /// "Minor axis (omit if circular)"
-        const ABS_MT_TOUCH_MINOR = 1 << 0x31,
+        const ABS_MT_TOUCH_MINOR = 1 << 0x31;
         /// "Major axis of approaching ellipse"
-        const ABS_MT_WIDTH_MAJOR = 1 << 0x32,
+        const ABS_MT_WIDTH_MAJOR = 1 << 0x32;
         /// "Minor axis (omit if circular)"
-        const ABS_MT_WIDTH_MINOR = 1 << 0x33,
+        const ABS_MT_WIDTH_MINOR = 1 << 0x33;
         /// "Ellipse orientation"
-        const ABS_MT_ORIENTATION = 1 << 0x34,
+        const ABS_MT_ORIENTATION = 1 << 0x34;
         /// "Center X touch position"
-        const ABS_MT_POSITION_X = 1 << 0x35,
+        const ABS_MT_POSITION_X = 1 << 0x35;
         /// "Center Y touch position"
-        const ABS_MT_POSITION_Y = 1 << 0x36,
+        const ABS_MT_POSITION_Y = 1 << 0x36;
         /// "Type of touching device"
-        const ABS_MT_TOOL_TYPE = 1 << 0x37,
+        const ABS_MT_TOOL_TYPE = 1 << 0x37;
         /// "Group a set of packets as a blob"
-        const ABS_MT_BLOB_ID = 1 << 0x38,
+        const ABS_MT_BLOB_ID = 1 << 0x38;
         /// "Unique ID of the initiated contact"
-        const ABS_MT_TRACKING_ID = 1 << 0x39,
+        const ABS_MT_TRACKING_ID = 1 << 0x39;
         /// "Pressure on contact area"
-        const ABS_MT_PRESSURE = 1 << 0x3a,
+        const ABS_MT_PRESSURE = 1 << 0x3a;
         /// "Contact over distance"
-        const ABS_MT_DISTANCE = 1 << 0x3b,
+        const ABS_MT_DISTANCE = 1 << 0x3b;
         /// "Center X tool position"
-        const ABS_MT_TOOL_X = 1 << 0x3c,
+        const ABS_MT_TOOL_X = 1 << 0x3c;
         /// "Center Y tool position"
-        const ABS_MT_TOOL_Y = 1 << 0x3d,
+        const ABS_MT_TOOL_Y = 1 << 0x3d;
     }
 }
 
 bitflags! {
-    pub flags Switch: u32 {
+    pub struct Switch: u32 {
         /// "set = lid shut"
-        const SW_LID = 1 << 0x00,
+        const SW_LID = 1 << 0x00;
         /// "set = tablet mode"
-        const SW_TABLET_MODE = 1 << 0x01,
+        const SW_TABLET_MODE = 1 << 0x01;
         /// "set = inserted"
-        const SW_HEADPHONE_INSERT = 1 << 0x02,
+        const SW_HEADPHONE_INSERT = 1 << 0x02;
         /// "rfkill master switch, type 'any'"
-        const SW_RFKILL_ALL = 1 << 0x03,
+        const SW_RFKILL_ALL = 1 << 0x03;
         /// "set = inserted"
-        const SW_MICROPHONE_INSERT = 1 << 0x04,
+        const SW_MICROPHONE_INSERT = 1 << 0x04;
         /// "set = plugged into doc"
-        const SW_DOCK = 1 << 0x05,
+        const SW_DOCK = 1 << 0x05;
         /// "set = inserted"
-        const SW_LINEOUT_INSERT = 1 << 0x06,
+        const SW_LINEOUT_INSERT = 1 << 0x06;
         /// "set = mechanical switch set"
-        const SW_JACK_PHYSICAL_INSERT = 1 << 0x07,
+        const SW_JACK_PHYSICAL_INSERT = 1 << 0x07;
         /// "set  = inserted"
-        const SW_VIDEOOUT_INSERT = 1 << 0x08,
+        const SW_VIDEOOUT_INSERT = 1 << 0x08;
         /// "set = lens covered"
-        const SW_CAMERA_LENS_COVER = 1 << 0x09,
+        const SW_CAMERA_LENS_COVER = 1 << 0x09;
         /// "set = keypad slide out"
-        const SW_KEYPAD_SLIDE = 1 << 0x0a,
+        const SW_KEYPAD_SLIDE = 1 << 0x0a;
         /// "set = front proximity sensor active"
-        const SW_FRONT_PROXIMITY = 1 << 0x0b,
+        const SW_FRONT_PROXIMITY = 1 << 0x0b;
         /// "set = rotate locked/disabled"
-        const SW_ROTATE_LOCK = 1 << 0x0c,
+        const SW_ROTATE_LOCK = 1 << 0x0c;
         /// "set = inserted"
-        const SW_LINEIN_INSERT = 1 << 0x0d,
+        const SW_LINEIN_INSERT = 1 << 0x0d;
         /// "set = device disabled"
-        const SW_MUTE_DEVICE = 1 << 0x0e,
+        const SW_MUTE_DEVICE = 1 << 0x0e;
         /// "set = pen inserted"
-        const SW_PEN_INSERTED = 1 << 0x0f,
-        const SW_MAX = 0xf,
+        const SW_PEN_INSERTED = 1 << 0x0f;
+        const SW_MAX = 0xf;
     }
 }
 
 bitflags! {
     /// LEDs specified by USB HID.
-    pub flags Led: u32 {
-        const LED_NUML = 1 << 0x00,
-        const LED_CAPSL = 1 << 0x01,
-        const LED_SCROLLL = 1 << 0x02,
-        const LED_COMPOSE = 1 << 0x03,
-        const LED_KANA = 1 << 0x04,
+    pub struct Led: u32 {
+        const LED_NUML = 1 << 0x00;
+        const LED_CAPSL = 1 << 0x01;
+        const LED_SCROLLL = 1 << 0x02;
+        const LED_COMPOSE = 1 << 0x03;
+        const LED_KANA = 1 << 0x04;
         /// "Stand-by"
-        const LED_SLEEP = 1 << 0x05,
-        const LED_SUSPEND = 1 << 0x06,
-        const LED_MUTE = 1 << 0x07,
+        const LED_SLEEP = 1 << 0x05;
+        const LED_SUSPEND = 1 << 0x06;
+        const LED_MUTE = 1 << 0x07;
         /// "Generic indicator"
-        const LED_MISC = 1 << 0x08,
+        const LED_MISC = 1 << 0x08;
         /// "Message waiting"
-        const LED_MAIL = 1 << 0x09,
+        const LED_MAIL = 1 << 0x09;
         /// "External power connected"
-        const LED_CHARGING = 1 << 0x0a,
-        const LED_MAX = 1 << 0x0f,
+        const LED_CHARGING = 1 << 0x0a;
+        const LED_MAX = 1 << 0x0f;
     }
 }
 
 bitflags! {
     /// Various miscellaneous event types. Current as of kernel 4.1.
-    pub flags Misc: u32 {
+    pub struct Misc: u32 {
         /// Serial number, only exported for tablets ("Transducer Serial Number")
-        const MSC_SERIAL = 1 << 0x00,
+        const MSC_SERIAL = 1 << 0x00;
         /// Only used by the PowerMate driver, right now.
-        const MSC_PULSELED = 1 << 0x01,
+        const MSC_PULSELED = 1 << 0x01;
         /// Completely unused.
-        const MSC_GESTURE = 1 << 0x02,
+        const MSC_GESTURE = 1 << 0x02;
         /// "Raw" event, rarely used.
-        const MSC_RAW = 1 << 0x03,
+        const MSC_RAW = 1 << 0x03;
         /// Key scancode
-        const MSC_SCAN = 1 << 0x04,
+        const MSC_SCAN = 1 << 0x04;
         /// Completely unused.
-        const MSC_TIMESTAMP = 1 << 0x05,
-        const MSC_MAX = 1 << 0x07,
+        const MSC_TIMESTAMP = 1 << 0x05;
+        const MSC_MAX = 1 << 0x07;
     }
 }
 
 bitflags! {
-    pub flags FFStatus: u32 {
-        const FF_STATUS_STOPPED	= 1 << 0x00,
-        const FF_STATUS_PLAYING	= 1 << 0x01,
+    pub struct FFStatus: u32 {
+        const FF_STATUS_STOPPED	= 1 << 0x00;
+        const FF_STATUS_PLAYING	= 1 << 0x01;
     }
 }
 
@@ -336,17 +336,17 @@ pub enum FFEffect {
 }
 
 bitflags! {
-    pub flags Repeat: u32 {
-        const REP_DELAY = 1 << 0x00,
-        const REP_PERIOD = 1 << 0x01,
+    pub struct Repeat: u32 {
+        const REP_DELAY = 1 << 0x00;
+        const REP_PERIOD = 1 << 0x01;
     }
 }
 
 bitflags! {
-    pub flags Sound: u32 {
-        const SND_CLICK = 1 << 0x00,
-        const SND_BELL = 1 << 0x01,
-        const SND_TONE = 1 << 0x02,
+    pub struct Sound: u32 {
+        const SND_CLICK = 1 << 0x00;
+        const SND_BELL = 1 << 0x01;
+        const SND_TONE = 1 << 0x02;
     }
 }
 
@@ -447,15 +447,15 @@ impl std::fmt::Debug for Device {
             .field("id", &self.id)
             .field("props", &self.props)
             .field("driver_version", &self.driver_version);
-        if self.ty.contains(SYNCHRONIZATION) {}
-        if self.ty.contains(KEY) {
+        if self.ty.contains(Types::SYNCHRONIZATION) {}
+        if self.ty.contains(Types::KEY) {
             ds.field("key_bits", &self.key_bits)
                 .field("key_vals", &self.state.key_vals);
         }
-        if self.ty.contains(RELATIVE) {
+        if self.ty.contains(Types::RELATIVE) {
             ds.field("rel", &self.rel);
         }
-        if self.ty.contains(ABSOLUTE) {
+        if self.ty.contains(Types::ABSOLUTE) {
             ds.field("abs", &self.abs);
             for idx in 0..0x3f {
                 let abs = 1 << idx;
@@ -469,26 +469,26 @@ impl std::fmt::Debug for Device {
                 }
             }
         }
-        if self.ty.contains(MISC) {}
-        if self.ty.contains(SWITCH) {
+        if self.ty.contains(Types::MISC) {}
+        if self.ty.contains(Types::SWITCH) {
             ds.field("switch", &self.switch)
                 .field("switch_vals", &self.state.switch_vals);
         }
-        if self.ty.contains(LED) {
+        if self.ty.contains(Types::LED) {
             ds.field("led", &self.led)
                 .field("led_vals", &self.state.led_vals);
         }
-        if self.ty.contains(SOUND) {
+        if self.ty.contains(Types::SOUND) {
             ds.field("snd", &self.snd);
         }
-        if self.ty.contains(REPEAT) {
+        if self.ty.contains(Types::REPEAT) {
             ds.field("rep", &self.rep);
         }
-        if self.ty.contains(FORCEFEEDBACK) {
+        if self.ty.contains(Types::FORCEFEEDBACK) {
             ds.field("ff", &self.ff);
         }
-        if self.ty.contains(POWER) {}
-        if self.ty.contains(FORCEFEEDBACKSTATUS) {
+        if self.ty.contains(Types::POWER) {}
+        if self.ty.contains(Types::FORCEFEEDBACKSTATUS) {
             ds.field("ff_stat", &self.ff_stat);
         }
         ds.finish()
@@ -541,9 +541,9 @@ impl std::fmt::Display for Device {
         writeln!(f, "  Version: 0x{:x}", self.id.version)?;
         writeln!(f, "  Properties: {:?}", self.props)?;
 
-        if self.ty.contains(SYNCHRONIZATION) {}
+        if self.ty.contains(Types::SYNCHRONIZATION) {}
 
-        if self.ty.contains(KEY) {
+        if self.ty.contains(Types::KEY) {
             writeln!(f, "  Keys supported:")?;
             for key_idx in 0..self.key_bits.len() {
                 if self.key_bits.contains(key_idx) {
@@ -562,10 +562,10 @@ impl std::fmt::Display for Device {
                 }
             }
         }
-        if self.ty.contains(RELATIVE) {
+        if self.ty.contains(Types::RELATIVE) {
             writeln!(f, "  Relative Axes: {:?}", self.rel)?;
         }
-        if self.ty.contains(ABSOLUTE) {
+        if self.ty.contains(Types::ABSOLUTE) {
             writeln!(f, "  Absolute Axes:")?;
             for idx in 0..0x3f {
                 let abs = 1 << idx;
@@ -581,14 +581,14 @@ impl std::fmt::Display for Device {
                 }
             }
         }
-        if self.ty.contains(MISC) {
+        if self.ty.contains(Types::MISC) {
             writeln!(f, "  Miscellaneous capabilities: {:?}", self.misc)?;
         }
-        if self.ty.contains(SWITCH) {
+        if self.ty.contains(Types::SWITCH) {
             writeln!(f, "  Switches:")?;
             for idx in 0..0xf {
                 let sw = 1 << idx;
-                if sw < SW_MAX.bits() && self.switch.bits() & sw == 1 {
+                if sw < Switch::SW_MAX.bits() && self.switch.bits() & sw == 1 {
                     writeln!(
                         f,
                         "    {:?} ({:?}, index {})",
@@ -599,11 +599,11 @@ impl std::fmt::Display for Device {
                 }
             }
         }
-        if self.ty.contains(LED) {
+        if self.ty.contains(Types::LED) {
             writeln!(f, "  LEDs:")?;
             for idx in 0..0xf {
                 let led = 1 << idx;
-                if led < LED_MAX.bits() && self.led.bits() & led == 1 {
+                if led < Led::LED_MAX.bits() && self.led.bits() & led == 1 {
                     writeln!(
                         f,
                         "    {:?} ({:?}, index {})",
@@ -614,19 +614,19 @@ impl std::fmt::Display for Device {
                 }
             }
         }
-        if self.ty.contains(SOUND) {
+        if self.ty.contains(Types::SOUND) {
             writeln!(f, "  Sound: {:?}", self.snd)?;
         }
-        if self.ty.contains(REPEAT) {
+        if self.ty.contains(Types::REPEAT) {
             writeln!(f, "  Repeats: {:?}", self.rep)?;
         }
-        if self.ty.contains(FORCEFEEDBACK) {
+        if self.ty.contains(Types::FORCEFEEDBACK) {
             writeln!(f, "  Force Feedback supported")?;
         }
-        if self.ty.contains(POWER) {
+        if self.ty.contains(Types::POWER) {
             writeln!(f, "  Power supported")?;
         }
-        if self.ty.contains(FORCEFEEDBACKSTATUS) {
+        if self.ty.contains(Types::FORCEFEEDBACKSTATUS) {
             writeln!(f, "  Force Feedback status supported")?;
         }
         Ok(())
@@ -738,13 +738,13 @@ impl Device {
             id: unsafe { std::mem::zeroed() },
             props: Props::empty(),
             driver_version: (0, 0, 0),
-            key_bits: FixedBitSet::with_capacity(KEY_MAX as usize),
+            key_bits: FixedBitSet::with_capacity(Key::KEY_MAX as usize),
             rel: RelativeAxis::empty(),
             abs: AbsoluteAxis::empty(),
             switch: Switch::empty(),
             led: Led::empty(),
             misc: Misc::empty(),
-            ff: FixedBitSet::with_capacity(FF_MAX as usize + 1),
+            ff: FixedBitSet::with_capacity(FFEffect::FF_MAX as usize + 1),
             ff_stat: FFStatus::empty(),
             rep: Repeat::empty(),
             snd: Sound::empty(),
@@ -755,7 +755,7 @@ impl Device {
                     tv_sec: 0,
                     tv_usec: 0,
                 },
-                key_vals: FixedBitSet::with_capacity(KEY_MAX as usize),
+                key_vals: FixedBitSet::with_capacity(Key::KEY_MAX as usize),
                 abs_vals: vec![],
                 switch_vals: FixedBitSet::with_capacity(0x10),
                 led_vals: FixedBitSet::with_capacity(0x10),
@@ -789,19 +789,19 @@ impl Device {
         )); // FIXME: handle old kernel
         dev.props = Props::from_bits(bits).expect("evdev: unexpected prop bits! report a bug");
 
-        if dev.ty.contains(KEY) {
+        if dev.ty.contains(Types::KEY) {
             do_ioctl!(eviocgbit(
                 fd,
-                KEY.number(),
+                Types::KEY.number(),
                 dev.key_bits.len() as libc::c_int,
                 dev.key_bits.as_mut_slice().as_mut_ptr() as *mut u8
             ));
         }
 
-        if dev.ty.contains(RELATIVE) {
+        if dev.ty.contains(Types::RELATIVE) {
             do_ioctl!(eviocgbit(
                 fd,
-                RELATIVE.number(),
+                Types::RELATIVE.number(),
                 0xf,
                 &mut bits as *mut u32 as *mut u8
             ));
@@ -809,10 +809,10 @@ impl Device {
                 RelativeAxis::from_bits(bits).expect("evdev: unexpected rel bits! report a bug");
         }
 
-        if dev.ty.contains(ABSOLUTE) {
+        if dev.ty.contains(Types::ABSOLUTE) {
             do_ioctl!(eviocgbit(
                 fd,
-                ABSOLUTE.number(),
+                Types::ABSOLUTE.number(),
                 0x3f,
                 &mut bits64 as *mut u64 as *mut u8
             ));
@@ -821,10 +821,10 @@ impl Device {
             dev.state.abs_vals = vec![input_absinfo::default(); 0x3f];
         }
 
-        if dev.ty.contains(SWITCH) {
+        if dev.ty.contains(Types::SWITCH) {
             do_ioctl!(eviocgbit(
                 fd,
-                SWITCH.number(),
+                Types::SWITCH.number(),
                 0xf,
                 &mut bits as *mut u32 as *mut u8
             ));
@@ -832,20 +832,20 @@ impl Device {
                 Switch::from_bits(bits).expect("evdev: unexpected switch bits! report a bug");
         }
 
-        if dev.ty.contains(LED) {
+        if dev.ty.contains(Types::LED) {
             do_ioctl!(eviocgbit(
                 fd,
-                LED.number(),
+                Types::LED.number(),
                 0xf,
                 &mut bits as *mut u32 as *mut u8
             ));
             dev.led = Led::from_bits(bits).expect("evdev: unexpected led bits! report a bug");
         }
 
-        if dev.ty.contains(MISC) {
+        if dev.ty.contains(Types::MISC) {
             do_ioctl!(eviocgbit(
                 fd,
-                MISC.number(),
+                Types::MISC.number(),
                 0x7,
                 &mut bits as *mut u32 as *mut u8
             ));
@@ -854,10 +854,10 @@ impl Device {
 
         //do_ioctl!(eviocgbit(fd, ffs(FORCEFEEDBACK.bits()), 0x7f, &mut bits as *mut u32 as *mut u8));
 
-        if dev.ty.contains(SOUND) {
+        if dev.ty.contains(Types::SOUND) {
             do_ioctl!(eviocgbit(
                 fd,
-                SOUND.number(),
+                Types::SOUND.number(),
                 0x7,
                 &mut bits as *mut u32 as *mut u8
             ));
@@ -873,17 +873,17 @@ impl Device {
     ///
     /// If there is an error at any point, the state will not be synchronized completely.
     pub fn sync_state(&mut self) -> Result<(), Error> {
-        if self.ty.contains(KEY) {
+        if self.ty.contains(Types::KEY) {
             do_ioctl!(eviocgkey(
                 self.fd,
                 transmute::<&mut [u32], &mut [u8]>(self.state.key_vals.as_mut_slice())
             ));
         }
-        if self.ty.contains(ABSOLUTE) {
+        if self.ty.contains(Types::ABSOLUTE) {
             for idx in 0..0x28 {
                 let abs = 1 << idx;
                 // ignore multitouch, we'll handle that later.
-                if abs < ABS_MT_SLOT.bits() && self.abs.bits() & abs != 0 {
+                if abs < AbsoluteAxis::ABS_MT_SLOT.bits() && self.abs.bits() & abs != 0 {
                     do_ioctl!(eviocgabs(
                         self.fd,
                         idx as u32,
@@ -892,13 +892,13 @@ impl Device {
                 }
             }
         }
-        if self.ty.contains(SWITCH) {
+        if self.ty.contains(Types::SWITCH) {
             do_ioctl!(eviocgsw(
                 self.fd,
                 transmute::<&mut [u32], &mut [u8]>(self.state.switch_vals.as_mut_slice())
             ));
         }
-        if self.ty.contains(LED) {
+        if self.ty.contains(Types::LED) {
             do_ioctl!(eviocgled(
                 self.fd,
                 transmute::<&mut [u32], &mut [u8]>(self.state.led_vals.as_mut_slice())
@@ -949,13 +949,13 @@ impl Device {
             tv_usec: time.tv_nsec / 1000,
         };
 
-        if self.ty.contains(KEY) {
+        if self.ty.contains(Types::KEY) {
             for key_idx in 0..self.key_bits.len() {
                 if self.key_bits.contains(key_idx) {
                     if old_state.key_vals[key_idx] != self.state.key_vals[key_idx] {
                         self.pending_events.push(raw::input_event {
                             time: time,
-                            _type: KEY.number(),
+                            _type: Types::KEY.number(),
                             code: key_idx as u16,
                             value: if self.state.key_vals[key_idx] { 1 } else { 0 },
                         });
@@ -963,14 +963,14 @@ impl Device {
                 }
             }
         }
-        if self.ty.contains(ABSOLUTE) {
+        if self.ty.contains(Types::ABSOLUTE) {
             for idx in 0..0x3f {
                 let abs = 1 << idx;
                 if self.abs.bits() & abs != 0 {
                     if old_state.abs_vals[idx as usize] != self.state.abs_vals[idx as usize] {
                         self.pending_events.push(raw::input_event {
                             time: time,
-                            _type: ABSOLUTE.number(),
+                            _type: Types::ABSOLUTE.number(),
                             code: idx as u16,
                             value: self.state.abs_vals[idx as usize].value,
                         });
@@ -978,14 +978,14 @@ impl Device {
                 }
             }
         }
-        if self.ty.contains(SWITCH) {
+        if self.ty.contains(Types::SWITCH) {
             for idx in 0..0xf {
                 let sw = 1 << idx;
-                if sw < SW_MAX.bits() && self.switch.bits() & sw == 1 {
+                if sw < Switch::SW_MAX.bits() && self.switch.bits() & sw == 1 {
                     if old_state.switch_vals[idx as usize] != self.state.switch_vals[idx as usize] {
                         self.pending_events.push(raw::input_event {
                             time: time,
-                            _type: SWITCH.number(),
+                            _type: Types::SWITCH.number(),
                             code: idx as u16,
                             value: if self.state.switch_vals[idx as usize] {
                                 1
@@ -997,14 +997,14 @@ impl Device {
                 }
             }
         }
-        if self.ty.contains(LED) {
+        if self.ty.contains(Types::LED) {
             for idx in 0..0xf {
                 let led = 1 << idx;
-                if led < LED_MAX.bits() && self.led.bits() & led == 1 {
+                if led < Led::LED_MAX.bits() && self.led.bits() & led == 1 {
                     if old_state.led_vals[idx as usize] != self.state.led_vals[idx as usize] {
                         self.pending_events.push(raw::input_event {
                             time: time,
-                            _type: LED.number(),
+                            _type: Types::LED.number(),
                             code: idx as u16,
                             value: if self.state.led_vals[idx as usize] {
                                 1
@@ -1019,7 +1019,7 @@ impl Device {
 
         self.pending_events.push(raw::input_event {
             time: time,
-            _type: SYNCHRONIZATION.number(),
+            _type: Types::SYNCHRONIZATION.number(),
             code: SYN_REPORT as u16,
             value: 0,
         });

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -19,12 +19,17 @@ pub struct input_event {
     pub value: i32,
 }
 impl ::std::default::Default for input_event {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 impl ::std::fmt::Debug for input_event {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "input_event {{ time: {{ tv_sec: {}, tv_usec: {} }}, _type: {}, code: {}, value: {}",
-               self.time.tv_sec, self.time.tv_usec, self._type, self.code, self.value)
+        write!(
+            f,
+            "input_event {{ time: {{ tv_sec: {}, tv_usec: {} }}, _type: {}, code: {}, value: {}",
+            self.time.tv_sec, self.time.tv_usec, self._type, self.code, self.value
+        )
     }
 }
 
@@ -66,8 +71,7 @@ impl Union_Unnamed16 {
         let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
         ::std::mem::transmute(raw.offset(0))
     }
-    pub unsafe fn condition(&mut self)
-     -> *mut [ff_condition_effect; 2usize] {
+    pub unsafe fn condition(&mut self) -> *mut [ff_condition_effect; 2usize] {
         let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
         ::std::mem::transmute(raw.offset(0))
     }
@@ -77,7 +81,9 @@ impl Union_Unnamed16 {
     }
 }
 impl ::std::default::Default for Union_Unnamed16 {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 
 #[repr(C)]
@@ -91,7 +97,9 @@ pub struct input_absinfo {
     pub resolution: i32,
 }
 impl ::std::default::Default for input_absinfo {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -103,7 +111,9 @@ pub struct input_keymap_entry {
     pub scancode: [u8; 32usize],
 }
 impl ::std::default::Default for input_keymap_entry {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -112,7 +122,9 @@ pub struct ff_replay {
     pub delay: u16,
 }
 impl ::std::default::Default for ff_replay {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -121,7 +133,9 @@ pub struct ff_trigger {
     pub interval: u16,
 }
 impl ::std::default::Default for ff_trigger {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -132,7 +146,9 @@ pub struct ff_envelope {
     pub fade_level: u16,
 }
 impl ::std::default::Default for ff_envelope {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -141,7 +157,9 @@ pub struct ff_constant_effect {
     pub envelope: ff_envelope,
 }
 impl ::std::default::Default for ff_constant_effect {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -151,7 +169,9 @@ pub struct ff_ramp_effect {
     pub envelope: ff_envelope,
 }
 impl ::std::default::Default for ff_ramp_effect {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -164,7 +184,9 @@ pub struct ff_condition_effect {
     pub center: i16,
 }
 impl ::std::default::Default for ff_condition_effect {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -179,7 +201,9 @@ pub struct ff_periodic_effect {
     pub custom_data: *mut i16,
 }
 impl ::std::default::Default for ff_periodic_effect {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -188,7 +212,9 @@ pub struct ff_rumble_effect {
     pub weak_magnitude: u16,
 }
 impl ::std::default::Default for ff_rumble_effect {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 
 ioctl!(read_buf eviocgname with b'E', 0x06; u8);
@@ -206,11 +232,27 @@ ioctl!(write_int eviocgrab with b'E', 0x90);
 ioctl!(write_int eviocrevoke with b'E', 0x91);
 ioctl!(write_int eviocsclockid with b'E', 0xa0);
 
-pub unsafe fn eviocgbit(fd: ::libc::c_int, ev: u32, len: ::libc::c_int, buf: *mut u8) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x20 + ev, len) as ::libc::c_ulong, buf))
+pub unsafe fn eviocgbit(
+    fd: ::libc::c_int,
+    ev: u32,
+    len: ::libc::c_int,
+    buf: *mut u8,
+) -> ::nix::Result<i32> {
+    convert_ioctl_res!(::nix::libc::ioctl(
+        fd,
+        ior!(b'E', 0x20 + ev, len) as ::libc::c_ulong,
+        buf
+    ))
 }
 
-pub unsafe fn eviocgabs(fd: ::libc::c_int, abs: u32, buf: *mut input_absinfo) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_ulong, buf))
+pub unsafe fn eviocgabs(
+    fd: ::libc::c_int,
+    abs: u32,
+    buf: *mut input_absinfo,
+) -> ::nix::Result<i32> {
+    convert_ioctl_res!(::nix::libc::ioctl(
+        fd,
+        ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_ulong,
+        buf
+    ))
 }
-


### PR DESCRIPTION
This fixes compile warnings with rust 1.43.1.

* `cargo fmt` code
* Replace `try` with `?` operator
* Update bitflags crate to fix deprecated `try` warnings