### PR TITLE
Force to request absinfo also onmultitouch axes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,10 +795,13 @@ impl Device {
             do_ioctl!(eviocgkey(self.fd, transmute::<&mut [u32], &mut [u8]>(self.state.key_vals.as_mut_slice())));
         }
         if self.ty.contains(ABSOLUTE) {
-            for idx in 0..0x28 {
+            for idx in 0..0x3f {
                 let abs = 1 << idx;
                 // ignore multitouch, we'll handle that later.
-                if abs < ABS_MT_SLOT.bits() && self.abs.bits() & abs != 0 {
+                //
+                // handling later removed. not sure what the intention of "handling that later" was
+                // the abs data seems to be fine (tested ABS_MT_POSITION_X/Y)
+                if self.abs.bits() & abs != 0 {
                     do_ioctl!(eviocgabs(self.fd, idx as u32, &mut self.state.abs_vals[idx as usize]));
                 }
             }


### PR DESCRIPTION
Hi,
I already asked in issue #20 why the multitouch axes were intentionally ignored when requesting axes.

The changes, I noted there, were added to [libremarkable](https://github.com/canselcik/libremarkable/) (a library to use the hardware of the [reMarkable](https://remarkable.com/) Gen 1 and working on Gen 2) so we can get the size of the multitouch screen for any device generation and do not need to hardcode the sizes which will make future updates easier.

Now, it turned out, that we can't just refer to my [fork](https://github.com/LinusCDE/evdev/) and publish this on crates.io ([related discussion that cause this PR](https://github.com/canselcik/libremarkable/commit/6f420e4e193b7767c52452a9241329960be9b9ab#commitcomment-45410368)). (I initially thought, waiting on the issue to get response after some months would be enough.)

I still don't know whether it has any side effects, but the changes didn't cause any noticed side effects for us, so I would presume it safe. I would be cool, if this could be merged soon and get a new version on crates.io, we can refer to, to be able to publish a new version of libremarkable again.