### PR TITLE
Update dependencies and fix cross-compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evdev"
-version = "0.11.0"
+version = "0.11.0-alpha.1"
 authors = ["Corey Richardson <corey@octayn.net>"]
 description = "evdev interface for Linux"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evdev"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Corey Richardson <corey@octayn.net>"]
 description = "evdev interface for Linux"
 license = "Apache-2.0 OR MIT"
@@ -8,11 +8,8 @@ repository = "https://github.com/cmr/evdev"
 documentation = "https://docs.rs/evdev"
 
 [dependencies]
-bitflags = "0.8.2"
+bitflags = "1.2"
 libc = "0.2.22"
-fixedbitset = "0.1.6"
-num = "0.1.37"
-nix = "0.9.0"
-
-[features]
-unstable = []
+fixedbitset = "0.3.2"
+num-traits = { version = "0.2", default-features = false }
+nix = "0.19.0"

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,14 +1,14 @@
-ioctl!(read eviocgeffects with b'E', 0x84; ::libc::c_int);
-ioctl!(read eviocgid with b'E', 0x02; /*struct*/ input_id);
-ioctl!(read eviocgkeycode with b'E', 0x04; [::libc::c_uint; 2]);
-ioctl!(read eviocgrep with b'E', 0x03; [::libc::c_uint; 2]);
-ioctl!(read eviocgversion with b'E', 0x01; ::libc::c_int);
-ioctl!(write_int eviocrmff with b'E', 0x81);
+ioctl_read!(eviocgeffects, b'E', 0x84, ::libc::c_int);
+ioctl_read!(eviocgid, b'E', 0x02, /*struct*/ input_id);
+ioctl_read!(eviocgkeycode, b'E', 0x04, [::libc::c_uint; 2]);
+ioctl_read!(eviocgrep, b'E', 0x03, [::libc::c_uint; 2]);
+ioctl_read!(eviocgversion, b'E', 0x01, ::libc::c_int);
+ioctl_write_int!(eviocrmff, b'E', 0x81);
 // ioctl!(read eviocgkeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
 // TODO #define EVIOCSFF _IOC ( _IOC_WRITE , 'E' , 0x80 , sizeof ( struct ff_effect ) )
-ioctl!(write_ptr eviocskeycode with b'E', 0x04; [::libc::c_uint; 2]);
+ioctl_write_ptr!(eviocskeycode, b'E', 0x04, [::libc::c_uint; 2]);
 // ioctl!(write_int eviocskeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
-ioctl!(write_ptr eviocsrep with b'E', 0x03; [::libc::c_uint; 2]);
+ioctl_write_ptr!(eviocsrep, b'E', 0x03, [::libc::c_uint; 2]);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -191,38 +191,25 @@ impl ::std::default::Default for ff_rumble_effect {
     fn default() -> Self { unsafe { ::std::mem::zeroed() } }
 }
 
-ioctl!(read_buf eviocgname with b'E', 0x06; u8);
-ioctl!(read_buf eviocgphys with b'E', 0x07; u8);
-ioctl!(read_buf eviocguniq with b'E', 0x08; u8);
-ioctl!(read_buf eviocgprop with b'E', 0x09; u8);
-ioctl!(read_buf eviocgmtslots with b'E', 0x0a; u8);
-ioctl!(read_buf eviocgkey with b'E', 0x18; u8);
-ioctl!(read_buf eviocgled with b'E', 0x19; u8);
-ioctl!(read_buf eviocgsnd with b'E', 0x1a; u8);
-ioctl!(read_buf eviocgsw with b'E', 0x1b; u8);
+ioctl_read_buf!(eviocgname, b'E', 0x06, u8);
+ioctl_read_buf!(eviocgphys, b'E', 0x07, u8);
+ioctl_read_buf!(eviocguniq, b'E', 0x08, u8);
+ioctl_read_buf!(eviocgprop, b'E', 0x09, u8);
+ioctl_read_buf!(eviocgmtslots, b'E', 0x0a, u8);
+ioctl_read_buf!(eviocgkey, b'E', 0x18, u8);
+ioctl_read_buf!(eviocgled, b'E', 0x19, u8);
+ioctl_read_buf!(eviocgsnd, b'E', 0x1a, u8);
+ioctl_read_buf!(eviocgsw, b'E', 0x1b, u8);
 
-ioctl!(write_ptr eviocsff with b'E', 0x80; ff_effect);
-ioctl!(write_int eviocgrab with b'E', 0x90);
-ioctl!(write_int eviocrevoke with b'E', 0x91);
-ioctl!(write_int eviocsclockid with b'E', 0xa0);
+ioctl_write_ptr!(eviocsff, b'E', 0x80, ff_effect);
+ioctl_write_int!(eviocgrab, b'E', 0x90);
+ioctl_write_int!(eviocrevoke, b'E', 0x91);
+ioctl_write_int!(eviocsclockid, b'E', 0xa0);
 
-#[cfg(target_arch = "arm")]
 pub unsafe fn eviocgbit(fd: ::libc::c_int, ev: u32, len: ::libc::c_int, buf: *mut u8) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x20 + ev, len) as ::libc::c_long, buf))
+    convert_ioctl_res!(::nix::libc::ioctl(fd, request_code_read!(b'E', 0x20 + ev, len), buf))
 }
 
-#[cfg(not(target_arch = "arm"))]
-pub unsafe fn eviocgbit(fd: ::libc::c_int, ev: u32, len: ::libc::c_int, buf: *mut u8) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x20 + ev, len) as ::libc::c_ulong, buf))
-}
-
-#[cfg(target_arch = "arm")]
 pub unsafe fn eviocgabs(fd: ::libc::c_int, abs: u32, buf: *mut input_absinfo) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_long, buf))
+    convert_ioctl_res!(::nix::libc::ioctl(fd, request_code_read!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()), buf))
 }
-
-#[cfg(not(target_arch = "arm"))]
-pub unsafe fn eviocgabs(fd: ::libc::c_int, abs: u32, buf: *mut input_absinfo) -> ::nix::Result<i32> {
-    convert_ioctl_res!(::nix::libc::ioctl(fd, ior!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()) as ::libc::c_ulong, buf))
-}
-


### PR DESCRIPTION
Updates `bitflags` to 1.2, `fixedbitset` to 1.3.2, and most critically updates `nix` to 0.19.

I've removed the manual casts to `c_ulong` in `eviocgbit` and `eviocgabs` because `request_code_read!` already contains platform-specific logic to ensure the request code type matches the ioctl call type on the target OS.

More generally addresses https://github.com/emberian/evdev/issues/22