### PR TITLE
Fix a bunch of unsoundness, and clean up some stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ fixedbitset = "0.3.2"
 num-derive = "0.3.3"
 num-traits = { version = "0.2", default-features = false }
 nix = "0.19.0"
+thiserror = "1.0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evdev"
-version = "0.11.0-alpha.2"
+version = "0.11.0-alpha.3"
 authors = ["Corey Richardson <corey@octayn.net>"]
 description = "evdev interface for Linux"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ edition = "2018"
 bitflags = "1.2"
 libc = "0.2.22"
 fixedbitset = "0.3.2"
+num-derive = "0.3.3"
 num-traits = { version = "0.2", default-features = false }
 nix = "0.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1112,3 +1112,24 @@ fn into_timeval(time: &SystemTime) -> Result<libc::timeval, std::time::SystemTim
         tv_usec: now_duration.subsec_micros() as libc::suseconds_t,
     })
 }
+
+#[cfg(test)]
+mod test {
+    use std::mem::MaybeUninit;
+
+    #[test]
+    fn align_to_mut_is_sane() {
+        // We assume align_to_mut -> u8 puts everything in inner. Let's double check.
+        let mut bits: u32 = 0;
+        let (prefix, inner, suffix) = unsafe {std::slice::from_mut(&mut bits).align_to_mut::<u8>()};
+        assert_eq!(prefix.len(), 0);
+        assert_eq!(inner.len(), std::mem::size_of::<u32>());
+        assert_eq!(suffix.len(), 0);
+
+        let mut ev: MaybeUninit<libc::input_event> = MaybeUninit::uninit();
+        let (prefix, inner, suffix) = unsafe {std::slice::from_mut(&mut ev).align_to_mut::<u8>()};
+        assert_eq!(prefix.len(), 0);
+        assert_eq!(inner.len(), std::mem::size_of::<libc::input_event>());
+        assert_eq!(suffix.len(), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod scancodes;
 use bitflags::bitflags;
 use fixedbitset::FixedBitSet;
 use num_traits::FromPrimitive;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::mem::size_of;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -59,24 +59,23 @@ ioctl_write_int!(eviocsclockid, b'E', 0xa0);
 pub unsafe fn eviocgbit(
     fd: ::libc::c_int,
     ev: u32,
-    len: ::libc::c_int,
-    buf: *mut u8,
+    buf: &mut [u8],
 ) -> ::nix::Result<c_int> {
     convert_ioctl_res!(::nix::libc::ioctl(
         fd,
-        request_code_read!(b'E', 0x20 + ev, len),
-        buf
+        request_code_read!(b'E', 0x20 + ev, buf.len()),
+        buf.as_mut_ptr()
     ))
 }
 
 pub unsafe fn eviocgabs(
     fd: ::libc::c_int,
     abs: u32,
-    buf: *mut input_absinfo,
+    buf: &mut input_absinfo,
 ) -> ::nix::Result<c_int> {
     convert_ioctl_res!(::nix::libc::ioctl(
         fd,
         request_code_read!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()),
-        buf
+        buf as *mut input_absinfo
     ))
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -19,6 +19,15 @@ pub(crate) const fn input_absinfo_default() -> input_absinfo {
     }
 }
 
+pub(crate) const fn input_id_default() -> input_id {
+    input_id {
+        bustype: 0,
+        vendor: 0,
+        product: 0,
+        version: 0,
+    }
+}
+
 ioctl_read!(eviocgeffects, b'E', 0x84, ::libc::c_int);
 ioctl_read!(eviocgid, b'E', 0x02, /*struct*/ input_id);
 ioctl_read!(eviocgkeycode, b'E', 0x04, [::libc::c_uint; 2]);

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,3 +1,4 @@
+use libc::c_int;
 pub use libc::{
     ff_condition_effect, ff_constant_effect, ff_effect, ff_envelope, ff_periodic_effect,
     ff_ramp_effect, ff_replay, ff_rumble_effect, ff_trigger, input_absinfo, input_event, input_id,
@@ -60,7 +61,7 @@ pub unsafe fn eviocgbit(
     ev: u32,
     len: ::libc::c_int,
     buf: *mut u8,
-) -> ::nix::Result<i32> {
+) -> ::nix::Result<c_int> {
     convert_ioctl_res!(::nix::libc::ioctl(
         fd,
         request_code_read!(b'E', 0x20 + ev, len),
@@ -72,7 +73,7 @@ pub unsafe fn eviocgabs(
     fd: ::libc::c_int,
     abs: u32,
     buf: *mut input_absinfo,
-) -> ::nix::Result<i32> {
+) -> ::nix::Result<c_int> {
     convert_ioctl_res!(::nix::libc::ioctl(
         fd,
         request_code_read!(b'E', 0x40 + abs, ::std::mem::size_of::<input_absinfo>()),

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,7 +1,23 @@
+pub use libc::{
+    ff_condition_effect, ff_constant_effect, ff_effect, ff_envelope, ff_periodic_effect,
+    ff_ramp_effect, ff_replay, ff_rumble_effect, ff_trigger, input_absinfo, input_event, input_id,
+    input_keymap_entry,
+};
 use nix::{
     convert_ioctl_res, ioctl_read, ioctl_read_buf, ioctl_write_int, ioctl_write_ptr,
     request_code_read,
 };
+
+pub(crate) const fn input_absinfo_default() -> input_absinfo {
+    input_absinfo {
+        value: 0,
+        minimum: 0,
+        maximum: 0,
+        fuzz: 0,
+        flat: 0,
+        resolution: 0,
+    }
+}
 
 ioctl_read!(eviocgeffects, b'E', 0x84, ::libc::c_int);
 ioctl_read!(eviocgid, b'E', 0x02, /*struct*/ input_id);
@@ -14,213 +30,6 @@ ioctl_write_int!(eviocrmff, b'E', 0x81);
 ioctl_write_ptr!(eviocskeycode, b'E', 0x04, [::libc::c_uint; 2]);
 // ioctl!(write_int eviocskeycode_v2 with b'E', 0x04; /*struct*/ input_keymap_entry);
 ioctl_write_ptr!(eviocsrep, b'E', 0x03, [::libc::c_uint; 2]);
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct input_event {
-    pub time: ::libc::timeval,
-    pub _type: u16,
-    pub code: u16,
-    pub value: i32,
-}
-impl ::std::default::Default for input_event {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-impl ::std::fmt::Debug for input_event {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(
-            f,
-            "input_event {{ time: {{ tv_sec: {}, tv_usec: {} }}, _type: {}, code: {}, value: {}",
-            self.time.tv_sec, self.time.tv_usec, self._type, self.code, self.value
-        )
-    }
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct input_id {
-    pub bustype: u16,
-    pub vendor: u16,
-    pub product: u16,
-    pub version: u16,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ff_effect {
-    pub _type: u16,
-    pub id: i16,
-    pub direction: u16,
-    pub trigger: ff_trigger,
-    pub replay: ff_replay,
-    pub u: Union_Unnamed16,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct Union_Unnamed16 {
-    pub _bindgen_data_: [u64; 4usize],
-}
-impl Union_Unnamed16 {
-    pub unsafe fn constant(&mut self) -> *mut ff_constant_effect {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn ramp(&mut self) -> *mut ff_ramp_effect {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn periodic(&mut self) -> *mut ff_periodic_effect {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn condition(&mut self) -> *mut [ff_condition_effect; 2usize] {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn rumble(&mut self) -> *mut ff_rumble_effect {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
-impl ::std::default::Default for Union_Unnamed16 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-pub struct input_absinfo {
-    pub value: i32,
-    pub minimum: i32,
-    pub maximum: i32,
-    pub fuzz: i32,
-    pub flat: i32,
-    pub resolution: i32,
-}
-impl ::std::default::Default for input_absinfo {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct input_keymap_entry {
-    pub flags: u8,
-    pub len: u8,
-    pub index: u16,
-    pub keycode: u32,
-    pub scancode: [u8; 32usize],
-}
-impl ::std::default::Default for input_keymap_entry {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_replay {
-    pub length: u16,
-    pub delay: u16,
-}
-impl ::std::default::Default for ff_replay {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_trigger {
-    pub button: u16,
-    pub interval: u16,
-}
-impl ::std::default::Default for ff_trigger {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_envelope {
-    pub attack_length: u16,
-    pub attack_level: u16,
-    pub fade_length: u16,
-    pub fade_level: u16,
-}
-impl ::std::default::Default for ff_envelope {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_constant_effect {
-    pub level: i16,
-    pub envelope: ff_envelope,
-}
-impl ::std::default::Default for ff_constant_effect {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_ramp_effect {
-    pub start_level: i16,
-    pub end_level: i16,
-    pub envelope: ff_envelope,
-}
-impl ::std::default::Default for ff_ramp_effect {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_condition_effect {
-    pub right_saturation: u16,
-    pub left_saturation: u16,
-    pub right_coeff: i16,
-    pub left_coeff: i16,
-    pub deadband: u16,
-    pub center: i16,
-}
-impl ::std::default::Default for ff_condition_effect {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_periodic_effect {
-    pub waveform: u16,
-    pub period: u16,
-    pub magnitude: i16,
-    pub offset: i16,
-    pub phase: u16,
-    pub envelope: ff_envelope,
-    pub custom_len: u32,
-    pub custom_data: *mut i16,
-}
-impl ::std::default::Default for ff_periodic_effect {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
-pub struct ff_rumble_effect {
-    pub strong_magnitude: u16,
-    pub weak_magnitude: u16,
-}
-impl ::std::default::Default for ff_rumble_effect {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
 
 ioctl_read_buf!(eviocgname, b'E', 0x06, u8);
 ioctl_read_buf!(eviocgphys, b'E', 0x07, u8);

--- a/src/scancodes.rs
+++ b/src/scancodes.rs
@@ -1,8 +1,10 @@
+use num_derive::FromPrimitive;
+
 /// Scancodes for key presses.
 ///
 /// Each represents a distinct key.
-#[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, FromPrimitive)]
 pub enum Key {
     KEY_RESERVED = 0,
     KEY_ESC = 1,

--- a/src/scancodes.rs
+++ b/src/scancodes.rs
@@ -528,5 +528,6 @@ pub enum Key {
 }
 
 impl Key {
-    pub const MAX: usize = 0x2ff;
+    // This needs to be a multiple of 8, otherwise we fetch keys we can't process
+    pub const MAX: usize = 0x300;
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,2 +1,0 @@
-// woo tests! should really test compensate_dropped... I don't even know how it's *supposed* to
-// behave yet though.


### PR DESCRIPTION
Closes https://github.com/emberian/evdev/issues/12 and https://github.com/emberian/evdev/issues/14

* Clean up quite a bit of unnecessary `unsafe` code, including direct calls to `clock_gettime`, `open`, and `read`, among others.
* Remove macros that hide `unsafe`. These were difficult to read and audit.
* Use `std::fs::File` to open and retain `/dev/event/*`. Eliminates the need for a custom Drop impl and improves unwind safety.
* Eliminate all use of `transmute`. Specifically there was a wildly unsafe transmute to the `Key` enum that resulted in undefined behavior. Replaced with safe calls to `num_traits::FromPrimitive`. Also removed or replaced transmute used for pointer and slice casts.
* `raw::eviocgbit` and `raw::eviocgabs` now accept mut slices instead of raw pointers (to match the nix macro-generated other unsafe function signatures in `raw`). There were several places internally where they were being invoked with number of bits instead of bytes for length, so this change makes those `unsafe` functions a little less inherently unsafe.
* No more casting out to `*mut u8` and back to `&mut [u8]`; as of Rust 1.30 `align_to_mut` allows a more safe aligned direct cast between slices.
* Replace manual struct implementations for things like input_event with imports from the libc crate.
* Remove a `tests.rs` file that contained no tests.