### PR TITLE
Ergonomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evdev"
-version = "0.11.0-alpha.5"
+version = "0.11.0-alpha.6"
 authors = ["Corey Richardson <corey@octayn.net>"]
 description = "evdev interface for Linux"
 license = "Apache-2.0 OR MIT"

--- a/src/device_state.rs
+++ b/src/device_state.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 /// A cached representation of device state at a certain time.
 #[derive(Debug)]
-pub struct DeviceState {
+pub(crate) struct DeviceState {
     /// The state corresponds to kernel state at this timestamp.
     pub(crate) timestamp: libc::timeval,
     /// Set = key pressed

--- a/src/device_state.rs
+++ b/src/device_state.rs
@@ -1,12 +1,12 @@
-use crate::constants::*;
+use crate::{constants::*, raw_stream::RawDevice};
 use crate::{AttributeSet, AttributeSetRef, InputEvent, InputEventKind, Key};
 use std::time::SystemTime;
 
-/// A cached representation of device state at a certain time.
+/// A **cached** representation of device state at a certain time.
 #[derive(Debug)]
-pub(crate) struct DeviceState {
+pub struct DeviceState {
     /// The state corresponds to kernel state at this timestamp.
-    pub(crate) timestamp: libc::timeval,
+    pub(crate) timestamp: SystemTime,
     /// Set = key pressed
     pub(crate) key_vals: Option<AttributeSet<Key>>,
     pub(crate) abs_vals: Option<Box<[libc::input_absinfo; AbsoluteAxisType::COUNT]>>,
@@ -37,9 +37,43 @@ impl Clone for DeviceState {
 }
 
 impl DeviceState {
+    /// Create an empty `DeviceState`. The `{abs,key,etc}_vals` for the returned state will return
+    /// `Some` if `supported_events()` contains that `EventType`.
+    pub(crate) fn new(device: &RawDevice) -> Self {
+        let supports = device.supported_events();
+
+        let key_vals = if supports.contains(EventType::KEY) {
+            Some(AttributeSet::new())
+        } else {
+            None
+        };
+        let abs_vals = if supports.contains(EventType::ABSOLUTE) {
+            Some(Box::new(crate::raw_stream::ABS_VALS_INIT))
+        } else {
+            None
+        };
+        let switch_vals = if supports.contains(EventType::SWITCH) {
+            Some(AttributeSet::new())
+        } else {
+            None
+        };
+        let led_vals = if supports.contains(EventType::LED) {
+            Some(AttributeSet::new())
+        } else {
+            None
+        };
+
+        DeviceState {
+            timestamp: std::time::UNIX_EPOCH,
+            key_vals,
+            abs_vals,
+            switch_vals,
+            led_vals,
+        }
+    }
     /// Returns the time when this snapshot was taken.
     pub fn timestamp(&self) -> SystemTime {
-        crate::timeval_to_systime(&self.timestamp)
+        self.timestamp
     }
 
     /// Returns the set of keys pressed when the snapshot was taken.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ use std::{fmt, io};
 // pub use crate::constants::FFEffect::*;
 pub use attribute_set::{AttributeSet, AttributeSetRef};
 pub use constants::*;
-pub use device_state::DeviceState;
 pub use inputid::*;
 pub use scancodes::*;
 pub use sync_stream::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,20 +28,37 @@
 //! # }
 //! ```
 //!
-//! This state can be queried. For example, the [`DeviceState::led_vals`] method will tell you which
-//! LEDs are currently lit on the device. As the application reads events, this state will be
-//! updated, and it will be fully synchronized with the kernel if the stream drops any events.
+//! The evdev crate exposes functions to query the current state of a device from the kernel, as
+//! well as a function that can be called continuously to provide an iterator over update events
+//! as they arrive.
 //!
-//! As the state changes, the kernel will write events into a ring buffer. The application can read
-//! from this ring buffer, thus retrieving events. However, if the ring buffer becomes full, the
-//! kernel will *drop* every event in the ring buffer and leave an event telling userspace that it
+//! # Synchronizing versus Raw modes
+//!
+//! This library can be used in either Raw or Synchronizing modes, which correspond roughly to
+//! evdev's `LIBEVDEV_READ_FLAG_NORMAL` and `LIBEVDEV_READ_FLAG_SYNC` modes, respectively.
+//! In both modes, calling `fetch_events` and driving the resulting iterator to completion
+//! will provide a stream of real-time events from the underlying kernel device state.
+//! As the state changes, the kernel will write events into a ring buffer. If the buffer becomes full, the
+//! kernel will *drop* events from the ring buffer and leave an event telling userspace that it
 //! did so. At this point, if the application were using the events it received to update its
 //! internal idea of what state the hardware device is in, it will be wrong: it is missing some
-//! events. This library tries to ease that pain, but it is best-effort. Events can never be
-//! recovered once lost. For example, if a switch is toggled twice, there will be two switch events
-//! in the buffer. However if the kernel needs to drop events, when the device goes to synchronize
-//! state with the kernel, only one (or zero, if the switch is in the same state as it was before
-//! the sync) switch events will be emulated.
+//! events.
+//!
+//! In synchronous mode, this library tries to ease that pain by removing the corrupted events
+//! and injecting fake events as if the device had updated normally. Note that this is best-effort;
+//! events can never be recovered once lost. This synchronization comes at a performance cost: each
+//! set of input events read from the kernel in turn updates an internal state buffer, and events
+//! must be internally held back until the end of each frame. If this latency is unacceptable or
+//! for any reason you want to see every event directly, a raw stream reader is also provided.
+//!
+//! As an example of how synchronization behaves, if a switch is toggled twice there will be two switch events
+//! in the buffer. However, if the kernel needs to drop events, when the device goes to synchronize
+//! state with the kernel only one (or zero, if the switch is in the same state as it was before
+//! the sync) switch events will be visible in the stream.
+//!
+//! This cache can also be queried. For example, the [`DeviceState::led_vals`] method will tell you which
+//! LEDs are currently lit on the device. As calling code consumes each iterator, this state will be
+//! updated, and it will be fully re-synchronized with the kernel if the stream drops any events.
 //!
 //! It is recommended that you dedicate a thread to processing input events, or use epoll or an
 //! async runtime with the fd returned by `<Device as AsRawFd>::as_raw_fd` to process events when
@@ -74,6 +91,7 @@ use std::{fmt, io};
 // pub use crate::constants::FFEffect::*;
 pub use attribute_set::{AttributeSet, AttributeSetRef};
 pub use constants::*;
+pub use device_state::DeviceState;
 pub use inputid::*;
 pub use scancodes::*;
 pub use sync_stream::*;

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -438,7 +438,8 @@ impl RawDevice {
     }
 
     /// Fetch the current kernel key state directly into the provided buffer.
-    /// If you don't already have a buffer, use [`get_key_state`] instead.
+    /// If you don't already have a buffer, you probably want
+    /// [`get_key_state`](Self::get_key_state) instead.
     #[inline]
     pub fn update_key_state(&self, key_vals: &mut AttributeSet<Key>) -> io::Result<()> {
         unsafe { sys::eviocgkey(self.as_raw_fd(), key_vals.as_mut_raw_slice()) }
@@ -447,7 +448,8 @@ impl RawDevice {
     }
 
     /// Fetch the current kernel absolute axis state directly into the provided buffer.
-    /// If you don't already have a buffer, use [`get_abs_state`] instead.
+    /// If you don't already have a buffer, you probably want
+    /// [`get_abs_state`](Self::get_abs_state) instead.
     #[inline]
     pub fn update_abs_state(
         &self,
@@ -469,7 +471,8 @@ impl RawDevice {
     }
 
     /// Fetch the current kernel switch state directly into the provided buffer.
-    /// If you don't already have a buffer, use [`get_switch_state`] instead.
+    /// If you don't already have a buffer, you probably want
+    /// [`get_switch_state`](Self::get_switch_state) instead.
     #[inline]
     pub fn update_switch_state(
         &self,
@@ -481,7 +484,8 @@ impl RawDevice {
     }
 
     /// Fetch the current kernel LED state directly into the provided buffer.
-    /// If you don't already have a buffer, use [`get_led_state`] instead.
+    /// If you don't already have a buffer, you probably want
+    /// [`get_led_state`](Self::get_led_state) instead.
     #[inline]
     pub fn update_led_state(&self, led_vals: &mut AttributeSet<LedType>) -> io::Result<()> {
         unsafe { sys::eviocgled(self.as_raw_fd(), led_vals.as_mut_raw_slice()) }

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -18,7 +18,7 @@ use std::{fmt, io};
 ///
 /// If `fetch_events()` isn't called often enough and the kernel drops events from its internal
 /// buffer, synthetic events will be injected into the iterator returned by `fetch_events()` and
-/// [`Device::state()`] will be kept up to date when `fetch_events()` is called.
+/// [`Device::cached_state()`] will be kept up to date when `fetch_events()` is called.
 pub struct Device {
     raw: RawDevice,
     prev_state: DeviceState,
@@ -52,7 +52,8 @@ impl Device {
     /// Returns the synchronization engine's current understanding (cache) of the device state.
     ///
     /// Note that this represents the internal cache of the synchronization engine as of the last
-    /// entry that was pulled out. The advantage to calling this instead of invoking [`get_key_state`]
+    /// entry that was pulled out. The advantage to calling this instead of invoking
+    /// [`get_key_state`](RawDevice::get_key_state)
     /// and the like directly is speed: because reading this cache doesn't require any syscalls it's
     /// easy to do inside a tight loop. The downside is that if the stream is not being driven quickly,
     /// this can very quickly get desynchronized from the kernel and provide inaccurate data.

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -1,6 +1,7 @@
 use crate::constants::*;
+use crate::device_state::DeviceState;
 use crate::raw_stream::RawDevice;
-use crate::{AttributeSetRef, DeviceState, InputEvent, InputEventKind, InputId, Key};
+use crate::{AttributeSetRef, InputEvent, InputEventKind, InputId, Key};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::{fmt, io};
@@ -47,7 +48,9 @@ impl Device {
         })
     }
 
-    pub fn state(&self) -> &DeviceState {
+    // TODO: Should we expose the internal inner state machine at all?
+    /// Returns the synchronization engine's current understanding of the device state.
+    fn cached_state(&self) -> &DeviceState {
         &self.state
     }
 


### PR DESCRIPTION
This exposes a non-cached way to directly access the kernel keys/switches/values. It also renames things a bit to make it clear that no external API apart from `fetch_events` will have any side effects on the internal sync state.

I'm pretty sure the documentation stating that the cached_state is updated automatically is incorrect-- the timestamps were certainly not being updated in real time. We should take another pass through that.