### PR TITLE
Update nix to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = ["tokio_1", "futures-core"]
 [dependencies]
 libc = "0.2.89"
 bitvec = "0.21"
-nix = "0.22"
+nix = "0.23"
 
 tokio_1 = { package = "tokio", version = "1.0", features = ["net"], optional = true }
 futures-core = { version = "0.3", optional = true }


### PR DESCRIPTION
Not sure what is required to validate this, but `cargo build`, `cargo build --release`, and `cargo test` ran successfully for me with rustc 1.55.0.