### PR TITLE
Update bitvec to 0.22.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = ["tokio_1", "futures-core"]
 
 [dependencies]
 libc = "0.2.89"
-bitvec = "0.21"
+bitvec = "0.22.3"
 nix = "0.23"
 
 tokio_1 = { package = "tokio", version = "1.0", features = ["net"], optional = true }


### PR DESCRIPTION
Again, `cargo build`, `cargo build --release`, and `cargo test` ran successfully for me with rustc 1.55.0.

This will bump the minimum supported Rust version to 1.51. However, with Rust 1.56 due in less than two weeks, that should be fine.