### PR TITLE
Update previous state during compensation.

### DIFF
--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -497,6 +497,7 @@ impl<'a> Iterator for FetchEventsSynced<'a> {
         // first: check if we need to emit compensatory events due to a SYN_DROPPED we found in the
         // last batch of blocks
         if let Some(ev) = compensate_events(&mut self.sync, &mut self.dev) {
+            self.dev.prev_state.process_event(ev);
             return Some(ev);
         }
         let state = &mut self.dev.state;


### PR DESCRIPTION
Otherwise, calling next() always returned the same event from compensate_events, because the previous state was never updated.

Fixes #53 