### PR TITLE
enable getting system path for Device

### DIFF
--- a/examples/_pick_device.rs
+++ b/examples/_pick_device.rs
@@ -9,7 +9,9 @@ pub fn pick_device() -> evdev::Device {
     if let Some(dev_file) = args.next() {
         evdev::Device::open(dev_file).unwrap()
     } else {
-        let mut devices = evdev::enumerate().collect::<Vec<_>>();
+        let mut devices = evdev::enumerate()
+            .map(|t| t.1)
+            .collect::<Vec<_>>();
         // readdir returns them in reverse order from their eventN names for some reason
         devices.reverse();
         for (i, d) in devices.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod uinput;
 mod tokio_stream;
 
 use std::fmt;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 // pub use crate::constants::FFEffect::*;
@@ -249,9 +250,9 @@ pub struct EnumerateDevices {
     inner: raw_stream::EnumerateDevices,
 }
 impl Iterator for EnumerateDevices {
-    type Item = Device;
-    fn next(&mut self) -> Option<Device> {
-        self.inner.next().map(Device::from_raw_device)
+    type Item = (PathBuf, Device);
+    fn next(&mut self) -> Option<(PathBuf, Device)> {
+        self.inner.next().map(|(pb, dev)| (pb, Device::from_raw_device(dev)))
     }
 }
 

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -2,7 +2,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{io, mem};
 
 use crate::constants::*;
@@ -656,8 +656,8 @@ pub struct EnumerateDevices {
     readdir: Option<std::fs::ReadDir>,
 }
 impl Iterator for EnumerateDevices {
-    type Item = RawDevice;
-    fn next(&mut self) -> Option<RawDevice> {
+    type Item = (PathBuf, RawDevice);
+    fn next(&mut self) -> Option<(PathBuf, RawDevice)> {
         use std::os::unix::ffi::OsStrExt;
         let readdir = self.readdir.as_mut()?;
         loop {
@@ -666,7 +666,7 @@ impl Iterator for EnumerateDevices {
                 let fname = path.file_name().unwrap();
                 if fname.as_bytes().starts_with(b"event") {
                     if let Ok(dev) = RawDevice::open(&path) {
-                        return Some(dev);
+                        return Some((path, dev));
                     }
                 }
             }

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -2,7 +2,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::{io, mem};
 
 use crate::constants::*;
@@ -68,7 +68,6 @@ pub struct RawDevice {
     supported_snd: Option<AttributeSet<SoundType>>,
     pub(crate) event_buf: Vec<libc::input_event>,
     grabbed: bool,
-    system_path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -226,7 +225,6 @@ impl RawDevice {
             auto_repeat,
             event_buf: Vec::new(),
             grabbed: false,
-            system_path: path.to_path_buf(),
         })
     }
 
@@ -383,11 +381,6 @@ impl RawDevice {
     /// speaker, for instance.
     pub fn supported_sounds(&self) -> Option<&AttributeSetRef<SoundType>> {
         self.supported_snd.as_deref()
-    }
-
-    /// Returns the system path used to open the device.
-    pub fn system_path(&self) -> &Path {
-        self.system_path.as_ref()
     }
 
     /// Read a maximum of `num` events into the internal buffer. If the underlying fd is not

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -2,7 +2,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{io, mem};
 
 use crate::constants::*;
@@ -68,6 +68,7 @@ pub struct RawDevice {
     supported_snd: Option<AttributeSet<SoundType>>,
     pub(crate) event_buf: Vec<libc::input_event>,
     grabbed: bool,
+    system_path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
@@ -225,6 +226,7 @@ impl RawDevice {
             auto_repeat,
             event_buf: Vec::new(),
             grabbed: false,
+            system_path: path.to_path_buf(),
         })
     }
 
@@ -381,6 +383,11 @@ impl RawDevice {
     /// speaker, for instance.
     pub fn supported_sounds(&self) -> Option<&AttributeSetRef<SoundType>> {
         self.supported_snd.as_deref()
+    }
+
+    /// Returns the system path used to open the device.
+    pub fn system_path(&self) -> &Path {
+        self.system_path.as_ref()
     }
 
     /// Read a maximum of `num` events into the internal buffer. If the underlying fd is not

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -253,6 +253,11 @@ impl Device {
         self.raw.supported_sounds()
     }
 
+    /// Returns the system path used to open the device.
+    pub fn system_path(&self) -> &Path {
+        self.raw.system_path()
+    }
+
     /// Retrieve the current keypress state directly via kernel syscall.
     pub fn get_key_state(&self) -> io::Result<AttributeSet<Key>> {
         self.raw.get_key_state()

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -253,11 +253,6 @@ impl Device {
         self.raw.supported_sounds()
     }
 
-    /// Returns the system path used to open the device.
-    pub fn system_path(&self) -> &Path {
-        self.raw.system_path()
-    }
-
     /// Retrieve the current keypress state directly via kernel syscall.
     pub fn get_key_state(&self) -> io::Result<AttributeSet<Key>> {
         self.raw.get_key_state()


### PR DESCRIPTION
I am working on a layering keymapper program and would like to use `evdev::enumerate` to help the user discover what keyboard devices are available for remapping. Currently it's not possible to get that information from a given `Device` instance. This PR makes that information available by preserving the system path used to instantiate each `Device` object.
