### PR TITLE
Add all bits and pieces for absolute axes in uinput and an example

### DIFF
--- a/examples/virtual_joystick.rs
+++ b/examples/virtual_joystick.rs
@@ -1,0 +1,34 @@
+// Create a virtual joystick, just while this is running.
+// Generally this requires root.
+
+use evdev::{uinput::VirtualDeviceBuilder, EventType, InputEvent, UinputAbsSetup, AbsInfo, AbsoluteAxisType};
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() -> std::io::Result<()> {
+    let abs_setup = AbsInfo::new(256, 0, 512, 20, 20, 1);
+    let abs_x = UinputAbsSetup::new(AbsoluteAxisType::ABS_X, abs_setup);
+
+    let mut device = VirtualDeviceBuilder::new()?
+        .name("Fake Joystick")
+        .with_absolute_axis(&abs_x)?
+        .build()
+        .unwrap();
+
+    let type_ = EventType::ABSOLUTE;
+    // Hopefully you don't have ABS_X bound to anything important.
+    let code = AbsoluteAxisType::ABS_X.0;
+
+    println!("Waiting for Ctrl-C...");
+    loop {
+        let down_event = InputEvent::new(type_, code, 0);
+        device.emit(&[down_event]).unwrap();
+        println!("Minned out.");
+        sleep(Duration::from_secs(2));
+
+        let up_event = InputEvent::new(type_, code, 512);
+        device.emit(&[up_event]).unwrap();
+        println!("Maxed out.");
+        sleep(Duration::from_secs(2));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,87 @@ pub enum InputEventKind {
     Other,
 }
 
+/// A wrapped `libc::input_absinfo` returned by EVIOCGABS and used with uinput to set up absolute
+/// axes
+///
+/// `input_absinfo` is a struct containing six fields:
+/// - `value: s32`
+/// - `minimum: s32`
+/// - `maximum: s32`
+/// - `fuzz: s32`
+/// - `flat: s32`
+/// - `resolution: s32`
+///
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct AbsInfo(libc::input_absinfo);
+
+impl AbsInfo {
+    #[inline]
+    pub fn value(&self) -> i32 {
+        self.0.value
+    }
+    #[inline]
+    pub fn minimum(&self) -> i32 {
+        self.0.minimum
+    }
+    #[inline]
+    pub fn maximum(&self) -> i32 {
+        self.0.maximum
+    }
+    #[inline]
+    pub fn fuzz(&self) -> i32 {
+        self.0.fuzz
+    }
+    #[inline]
+    pub fn flat(&self) -> i32 {
+        self.0.flat
+    }
+    #[inline]
+    pub fn resolution(&self) -> i32 {
+        self.0.resolution
+    }
+
+    /// Creates a new AbsInfo, particurarily useful for uinput
+    pub fn new(value: i32, minimum: i32, maximum: i32, fuzz: i32, flat: i32, resolution: i32) -> Self {
+        AbsInfo(libc::input_absinfo {
+            value,
+            minimum,
+            maximum,
+            fuzz,
+            flat,
+            resolution,
+        })
+    }
+}
+
+/// A wrapped `libc::uinput_abs_setup`, used to set up analogue axes with uinput
+///
+/// `uinput_abs_setup` is a struct containing two fields:
+/// - `code: u16`
+/// - `absinfo: input_absinfo`
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct UinputAbsSetup(libc::uinput_abs_setup);
+
+impl UinputAbsSetup {
+    #[inline]
+    pub fn code(&self) -> u16 {
+        self.0.code
+    }
+    #[inline]
+    pub fn absinfo(&self) -> AbsInfo {
+        AbsInfo(self.0.absinfo)
+    }
+    /// Creates new UinputAbsSetup
+    pub fn new(code: AbsoluteAxisType, absinfo: AbsInfo) -> Self {
+        UinputAbsSetup(libc::uinput_abs_setup {
+            code: code.0,
+            absinfo: absinfo.0,
+        })
+    }
+}
+
 /// A wrapped `libc::input_event` returned by the input device via the kernel.
 ///
 /// `input_event` is a struct containing four fields:

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,5 +1,5 @@
 use libc::c_int;
-use libc::{ff_effect, input_absinfo, input_id, input_keymap_entry, uinput_setup};
+use libc::{ff_effect, input_absinfo, input_id, input_keymap_entry, uinput_setup, uinput_abs_setup};
 // use libc::{
 //     ff_condition_effect, ff_constant_effect, ff_envelope, ff_periodic_effect, ff_ramp_effect,
 //     ff_replay, ff_rumble_effect, ff_trigger, input_event, input_keymap_entry,
@@ -39,6 +39,7 @@ ioctl_write_int!(eviocsclockid, b'E', 0xa0);
 
 const UINPUT_IOCTL_BASE: u8 = b'U';
 ioctl_write_ptr!(ui_dev_setup, UINPUT_IOCTL_BASE, 3, uinput_setup);
+ioctl_write_ptr!(ui_abs_setup, UINPUT_IOCTL_BASE, 4, uinput_abs_setup);
 ioctl_none!(ui_dev_create, UINPUT_IOCTL_BASE, 1);
 
 ioctl_write_int!(ui_set_evbit, UINPUT_IOCTL_BASE, 100);


### PR DESCRIPTION
I wasn't really sure where to place `UinputAbsSetup` struct... perhaps `src/uinput.rs`?
And listing out all getters for fields of both structs that I added looks like a hack but I couldn't think of a better way.