### PR TITLE
implement get_sys_path() and dev node iterator for virtual devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.121"
 bitvec = "1.0.0"
 nix = "0.23"
 
-tokio_1 = { package = "tokio", version = "1.17", features = ["net"], optional = true }
+tokio_1 = { package = "tokio", version = "1.17", features = ["fs", "net"], optional = true }
 futures-core = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -54,6 +54,17 @@ ioctl_write_buf!(ui_set_phys, UINPUT_IOCTL_BASE, 108, u8);
 ioctl_write_int!(ui_set_swbit, UINPUT_IOCTL_BASE, 109);
 ioctl_write_int!(ui_set_propbit, UINPUT_IOCTL_BASE, 110);
 
+pub unsafe fn ui_get_sysname(
+    fd: ::libc::c_int,
+    bytes: &mut [u8],
+) -> ::nix::Result<c_int> {
+    convert_ioctl_res!(::nix::libc::ioctl(
+        fd,
+        request_code_read!(UINPUT_IOCTL_BASE, 300, bytes.len()),
+        bytes.as_mut_ptr(),
+    ))
+}
+
 macro_rules! eviocgbit_ioctl {
     ($mac:ident!($name:ident, $ev:ident, $ty:ty)) => {
         eviocgbit_ioctl!($mac!($name, $crate::EventType::$ev.0, $ty));

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -199,7 +199,7 @@ impl VirtualDevice {
 
     /// Get the syspaths of the corresponding device nodes in /dev/input.
     #[cfg(not(feature = "tokio"))]
-    pub fn enumerate_dev_nodes(&mut self) -> io::Result<DevNodes> {
+    pub fn enumerate_dev_nodes_blocking(&mut self) -> io::Result<DevNodes> {
         let path = self.get_syspath()?;
         let dir = std::fs::read_dir(path)?;
 

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -198,11 +198,11 @@ impl VirtualDevice {
     }
 
     /// Get the syspaths of the corresponding device nodes in /dev/input.
-    pub fn enumerate_dev_nodes_blocking(&mut self) -> io::Result<DevNodes> {
+    pub fn enumerate_dev_nodes_blocking(&mut self) -> io::Result<DevNodesBlocking> {
         let path = self.get_syspath()?;
         let dir = std::fs::read_dir(path)?;
 
-        Ok(DevNodes {
+        Ok(DevNodesBlocking {
             dir,
         })
     }
@@ -234,13 +234,11 @@ impl VirtualDevice {
 
 /// This struct is returned from the [VirtualDevice::enumerate_dev_nodes] function and will yield
 /// the syspaths corresponding to the virtual device. These are of the form `/dev/input123`.
-#[cfg(not(feature = "tokio"))]
-pub struct DevNodes {
+pub struct DevNodesBlocking {
     dir: std::fs::ReadDir,
 }
 
-#[cfg(not(feature = "tokio"))]
-impl Iterator for DevNodes {
+impl Iterator for DevNodesBlocking {
     type Item = io::Result<PathBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -190,7 +190,7 @@ impl VirtualDevice {
             bytes.truncate(end);
         }
 
-        let s = std::str::from_utf8(&bytes).expect("invalid sys path");
+        let s = String::from_utf8_lossy(&bytes).into_owned();
         let mut path = PathBuf::from(SYSFS_PATH);
         path.push(s);
 

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -284,24 +284,18 @@ impl DevNodes {
         loop {
             let path = self.dir.next_entry().await?
                 // Map the directory name to its file name.
-                .map(|entry| entry.map(|entry|
-                    entry.file_name().to_string_lossy().to_owned().to_string()
-                ))
+                .map(|entry| entry.file_name().to_string_lossy().to_owned().to_string())
                 // Ignore file names that do not start with "event".
-                .filter(|name| name
-                    .as_ref()
-                    .map(|name| name.starts_with("event"))
-                    .unwrap_or(true)
-                )
+                .filter(|name| name.starts_with("event"))
                 // Construct the path of the form `/dev/input/eventX`.
-                .map(|name| name.map(|name| {
+                .map(|name| {
                     let mut path = PathBuf::from(DEV_PATH);
                     path.push(name);
                     path
-                }));
+                });
 
             if let Some(value) = path {
-                return Some(value);
+                return Ok(Some(value));
             }
         }
     }

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -198,7 +198,6 @@ impl VirtualDevice {
     }
 
     /// Get the syspaths of the corresponding device nodes in /dev/input.
-    #[cfg(not(feature = "tokio"))]
     pub fn enumerate_dev_nodes_blocking(&mut self) -> io::Result<DevNodes> {
         let path = self.get_syspath()?;
         let dir = std::fs::read_dir(path)?;


### PR DESCRIPTION
This addresses issue #70 by:
 - Implementing the ui_get_sysname ioctl.
 - Using the aforementioned ioctl to implement `VirtualDevice::get_syspath()` function, which returns the syspath of the form `/sys/devices/virtual/input/inputX` for the virtual device.
 - Adding both a synchronous and asynchronous version of `VirtualDevice::enumerate_dev_nodes()` depending on the `tokio` feature flag that essentially yields an iterator over the devices nodes of the form `/dev/input/eventX` that correspond to the virtual device.