### PR TITLE
implement EventStream::device_mut()

### DIFF
--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -710,6 +710,11 @@ mod tokio_stream {
             self.device.get_ref()
         }
 
+        /// Returns a mutable reference to the underlying device.
+        pub fn device_mut(&mut self) -> &mut RawDevice {
+            self.device.get_mut()
+        }
+
         /// Try to wait for the next event in this stream. Any errors are likely to be fatal, i.e.
         /// any calls afterwards will likely error as well.
         pub async fn next_event(&mut self) -> io::Result<InputEvent> {


### PR DESCRIPTION
Currently it is not possible to get a mutable reference to the `RawDevice` from an `EventStream`, which is needed for `RawDevice::ungrab()`. This implements `EventStream::device_mut()` to return a mutable reference.