### PR TITLE
implement Error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tokio = ["tokio_1", "futures-core"]
 libc = "0.2.121"
 bitvec = "1.0.0"
 nix = "0.23"
+thiserror = "1"
 
 tokio_1 = { package = "tokio", version = "1.17", features = ["net"], optional = true }
 futures-core = { version = "0.3", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid event kind")]
+    InvalidEvent,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Nix(#[from] nix::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ mod attribute_set;
 
 mod constants;
 mod device_state;
+mod error;
 mod inputid;
 pub mod raw_stream;
 mod scancodes;
@@ -109,6 +110,7 @@ use std::time::{Duration, SystemTime};
 pub use attribute_set::{AttributeSet, AttributeSetRef};
 pub use constants::*;
 pub use device_state::DeviceState;
+pub use error::Error;
 pub use inputid::*;
 pub use raw_stream::AutoRepeat;
 pub use scancodes::*;


### PR DESCRIPTION
This uses the `thiserror` crate to implement a separate `Error` type to prepare for PR #74.