### PR TITLE
Implement serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/evdev"
 edition = "2021"
 
 [features]
-serde = ["serde_1"]
+serde = ["serde_1", "paste"]
 tokio = ["tokio_1", "futures-core"]
 
 [dependencies]
@@ -17,7 +17,7 @@ libc = "0.2.121"
 bitvec = "1.0.0"
 nix = "0.23"
 thiserror = "1"
-paste = "1.0"
+paste = { version = "1.0", optional = true }
 
 serde_1 = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 tokio_1 = { package = "tokio", version = "1.17", features = ["fs", "net"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/evdev"
 edition = "2021"
 
 [features]
+serde = ["serde_1"]
 tokio = ["tokio_1", "futures-core"]
 
 [dependencies]
@@ -16,7 +17,9 @@ libc = "0.2.121"
 bitvec = "1.0.0"
 nix = "0.23"
 thiserror = "1"
+paste = "1.0"
 
+serde_1 = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 tokio_1 = { package = "tokio", version = "1.17", features = ["fs", "net"], optional = true }
 futures-core = { version = "0.3", optional = true }
 

--- a/src/attribute_set.rs
+++ b/src/attribute_set.rs
@@ -244,9 +244,7 @@ macro_rules! evdev_enum {
         }
         #[cfg(feature = "serde")]
         paste::paste! {
-            #[cfg(feature = "serde")]
             struct [<$t Visitor>];
-            #[cfg(feature = "serde")]
             impl<'de> serde_1::de::Visitor<'de> for [<$t Visitor>] {
                 type Value = $t;
 
@@ -264,7 +262,6 @@ macro_rules! evdev_enum {
                     }
                 }
             }
-            #[cfg(feature = "serde")]
             impl<'de> serde_1::Deserialize<'de> for $t {
                 fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
                 where

--- a/src/attribute_set.rs
+++ b/src/attribute_set.rs
@@ -227,5 +227,51 @@ macro_rules! evdev_enum {
                 self.0 as _
             }
         }
+        #[cfg(feature = "serde")]
+        #[allow(unreachable_patterns)]
+        impl serde_1::Serialize for $t {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde_1::ser::Serializer,
+            {
+                let value = match *self {
+                    $(Self::$c => stringify!($c),)*
+                    _ => unreachable!(),
+                };
+
+                serializer.serialize_str(value)
+            }
+        }
+        paste::paste! {
+            #[cfg(feature = "serde")]
+            struct [<$t Visitor>];
+            #[cfg(feature = "serde")]
+            impl<'de> serde_1::de::Visitor<'de> for [<$t Visitor>] {
+                type Value = $t;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(formatter, "a string with any of the constants in {}", stringify!($t))
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: serde_1::de::Error,
+                {
+                    match s.to_lowercase().as_str() {
+                        $(stringify!([<$c:lower>]) => Ok($t::$c),)*
+                        _ => Err(serde_1::de::Error::invalid_value(serde_1::de::Unexpected::Str(s), &self)),
+                    }
+                }
+            }
+            #[cfg(feature = "serde")]
+            impl<'de> serde_1::Deserialize<'de> for $t {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde_1::de::Deserializer<'de>,
+                {
+                    deserializer.deserialize_str([<$t Visitor>])
+                }
+            }
+        }
     }
 }

--- a/src/attribute_set.rs
+++ b/src/attribute_set.rs
@@ -242,6 +242,7 @@ macro_rules! evdev_enum {
                 serializer.serialize_str(value)
             }
         }
+        #[cfg(feature = "serde")]
         paste::paste! {
             #[cfg(feature = "serde")]
             struct [<$t Visitor>];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,9 @@ mod sync_stream;
 mod sys;
 pub mod uinput;
 
+#[cfg(feature = "serde")]
+use serde_1::{Deserialize, Serialize};
+
 use std::fmt;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -122,6 +125,8 @@ const EVENT_BATCH_SIZE: usize = 32;
 ///
 /// Note that this does not capture an event's value, just the type and code.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub enum InputEventKind {
     Synchronization(Synchronization),
     Key(Key),


### PR DESCRIPTION
This PR adds serialization/deserialization support using serde for the constants defined using the `evdev_enum!` macro, and in addition derives `Serialize` and `Deserialize` for `InputEventKind`.

The changelog is as follows:

- Add `serde` as an optional dependency.
- Add `paste` to help out with the macro logic in the `evdev_enum!` macro.
- Implement a custom serializer and deserializer in the `evdev_enum!` macro for `$t`.
- Derive `Serialize` and `Deserialize` for `InputEventKind`.