### PR TITLE
Release 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- a `CHANELOG.md` with a changelog for each new release.
+- a `CHANGELOG.md` with a changelog for each new release.
 - Force feedback support [#74](https://github.com/emberian/evdev/pull/74).
 - Implement serde support for `evdev_enum!` types and `InputEventKind` [#76](https://github.com/emberian/evdev/pull/76).
 - Implement `VirtualDevice::get_sys_path()` as well as an iterator over the device node paths for virtual devices [#72](https://github.com/emberian/evdev/pull/72).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- a `CHANGELOG.md` with a changelog for each new release.
+- Add a `CHANGELOG.md` with a changelog for each new release.
 - Force feedback support [#74](https://github.com/emberian/evdev/pull/74).
 - Implement serde support for `evdev_enum!` types and `InputEventKind` [#76](https://github.com/emberian/evdev/pull/76).
 - Implement `VirtualDevice::get_sys_path()` as well as an iterator over the device node paths for virtual devices [#72](https://github.com/emberian/evdev/pull/72).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## evdev 0.11.6 (2022-08-03)
+[372d000...HEAD](https://github.com/emberian/evdev/compare/372d000...HEAD)
+
+### Added
+
+- a `CHANELOG.md` with a changelog for each new release.
+- Force feedback support [#74](https://github.com/emberian/evdev/pull/74).
+- Implement serde support for `evdev_enum!` types and `InputEventKind` [#76](https://github.com/emberian/evdev/pull/76).
+- Implement `VirtualDevice::get_sys_path()` as well as an iterator over the device node paths for virtual devices [#72](https://github.com/emberian/evdev/pull/72).
+- Implement an `Error` type [#75](https://github.com/emberian/evdev/pull/75).
+- Add `EventStream::device_mut()` to get a mutable reference to `RawDevice` [#73](https://github.com/emberian/evdev/pull/73).
+- Add support for absolute axes for virtual devices [#71](https://github.com/emberian/evdev/pull/71).
+
+### Changed
+
+### Fixed
+
+- Documentation and code tidying [#67](https://github.com/emberian/evdev/pull/67).
+
+## evdev 0.11.5 (2022-03-05)
+[099b6e9...372d000](https://github.com/emberian/evdev/compare/099b6e9...372d000)
+
+### Added
+
+- Introduce `RawDevice::sys_path` and `Device::sys_path` [#62](https://github.com/emberian/evdev/pull/62).
+- Implement `FromIterator` for `AttributeSet`.
+
+### Changed
+
+### Fixed
+
+## evdev 0.11.4 (2022-01-12)
+[1d020f1...099b6e9](https://github.com/emberian/evdev/compare/1d020f1...099b6e9)
+
+### Added
+
+### Changed
+
+- Update bitvec to 1.0.
+
+### Fixed
+
+## evdev 0.11.3 (2021-12-07)
+[898bb5c...1d020f1](https://github.com/emberian/evdev/compare/898bb5c...1d020f1)
+
+### Added
+
+- Introduce `RawDevice::send_event` and `Device::send_event` to toggle LEDs, play sounds and play force feedback effects [#60](https://github.com/emberian/evdev/pull/60).
+
+### Changed
+
+### Fixed
+
+- Fix a bug in `compensate_events` where it returned the same event when invoking `next()` multiple times [#61](https://github.com/emberian/evdev/pull/61).
+
+## evdev 0.11.2 (2021-12-03)
+[763ef01...898bb5c](https://github.com/emberian/evdev/compare/763ef01...898bb5c)
+
+### Added
+
+### Changed
+
+- Update bitvec to 1.0.0-rc1.
+
+### Fixed
+
+## evdev 0.11.1 (2021-10-08)
+[1898f49...763ef01](https://github.com/emberian/evdev/compare/1898f49...763ef01)
+
+### Added
+
+- Implement `Device::grab` and `Device::ungrab`
+- Implement `VirtualDeviceBuilder::with_switches`.
+- Support autorepeats and getting keymap entries.
+
+### Changed
+
+- Update nix to 0.23.
+
+### Fixed
+
+## evdev 0.11.0 (2021-04-01)
+[79b6c2b...1898f49](https://github.com/emberian/evdev/compare/79b6c2b...1898f49)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evdev"
-version = "0.11.5"
+version = "0.11.6"
 authors = ["Corey Richardson <corey@octayn.net>"]
 description = "evdev interface for Linux"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ pull request.
 A good introduction is the [evtest.rs](examples/evtest) example (which roughly
 corresponds to the userspace [evtest](https://cgit.freedesktop.org/evtest/)
 tool.
+
+Releases
+========
+
+Detailed release notes are available in this repository at [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ in a higher-level crate, likely supporting multiple platforms.
 Example
 =======
 
-See <examples/evtest.rs> for an example of using this library (which roughly
+Plenty of nice examples of how to use this crate can be found in the
+[examples](examples) directory of this repository. If you feel like an example of
+how to use a certain part of the evdev crate is missing, then feel free to open a
+pull request.
+
+A good introduction is the [evtest.rs](examples/evtest) example (which roughly
 corresponds to the userspace [evtest](https://cgit.freedesktop.org/evtest/)
 tool.


### PR DESCRIPTION
This PR mostly prepares everything for evdev 0.11.6 with all the new goodies that landed upstream:

- Update the example section in the README, since we have plenty of examples now.
- Add a CHANGELOG.md inspired by the one from Cargo.
- Add a link to the CHANGELOG.md from the README.
- Release evdev 0.11.6 (I am guessing we need @coolreader18 to publish this on Cargo once done).

This also addresses issue #70.