### PR TITLE
Improve FFEffect and add EventStream::device_mut().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Added
 
+- Add missing `EventStream::device_mut()` in `sync_stream.rs`.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- Publicly export `FFEffect` from root.
 - Add `FFEffect::id()` as an accessor for the effect ID.
 - Add missing `EventStream::device_mut()` in `sync_stream.rs`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- Add `FFEffect::id()` as an accessor for the effect ID.
 - Add missing `EventStream::device_mut()` in `sync_stream.rs`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- Document `FFEffect`.
 - Publicly export `FFEffect` from root.
 - Add `FFEffect::id()` as an accessor for the effect ID.
 - Add missing `EventStream::device_mut()` in `sync_stream.rs`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub use device_state::DeviceState;
 pub use error::Error;
 pub use ff::*;
 pub use inputid::*;
-pub use raw_stream::AutoRepeat;
+pub use raw_stream::{AutoRepeat, FFEffect};
 pub use scancodes::*;
 pub use sync_stream::*;
 

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -42,6 +42,8 @@ pub(crate) const ABS_VALS_INIT: [libc::input_absinfo; AbsoluteAxisType::COUNT] =
 
 const INPUT_KEYMAP_BY_INDEX: u8 = 1;
 
+/// Represents a force feedback effect that has been successfully uploaded to the device for
+/// playback.
 #[derive(Debug)]
 pub struct FFEffect {
     file: File,

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -49,6 +49,11 @@ pub struct FFEffect {
 }
 
 impl FFEffect {
+    /// Returns the effect ID.
+    pub fn id(&self) -> u16 {
+        self.id
+    }
+
     /// Plays the force feedback effect with the `count` argument specifying how often the effect
     /// should be played.
     pub fn play(&mut self, count: i32) -> io::Result<()> {

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -761,6 +761,11 @@ mod tokio_stream {
             self.device.get_ref()
         }
 
+        /// Returns a mutable reference to the underlying device
+        pub fn device_mut(&self) -> &mut Device {
+            self.device.get_mut()
+        }
+
         /// Try to wait for the next event in this stream. Any errors are likely to be fatal, i.e.
         /// any calls afterwards will likely error as well.
         pub async fn next_event(&mut self) -> io::Result<InputEvent> {


### PR DESCRIPTION
This is mostly a collection of small improvements:

- PR #73 missed the `EventStream` implementation in `sync_stream.rs`. So this adds `EventStream::device_mut()` there too.
- Implement `FFEffect::id()` as an accessor to be able to grab the ID. It can be useful when creating a virtual device that almost directly exposes the force feedback effects of another actual device.
- Missing public export for `FFEffect` from the crate root.
- Add some documentation for `FFEffect` while I am at it.