### PR TITLE
fix DevNodesBlocking iterator to not block indefinitely when exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Changelog
 
+## evdev next
+[c0bd8dd...HEAD](https://github.com/emberian/evdev/compare/c0bd8dd...HEAD)
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Make sure that the `DevNodesBlocking` iterator is not blocking indefinitely when all entries in the directory have been exhausted.
+
 ## evdev 0.11.6 (2022-08-03)
-[372d000...HEAD](https://github.com/emberian/evdev/compare/372d000...HEAD)
+[372d000...c0bd8dd](https://github.com/emberian/evdev/compare/372d000...c0bd8dd)
 
 ### Added
 


### PR DESCRIPTION
This PR fixes an issue where the `DevNodesBlocking` iterator blocks indefinitely when the underlying `ReadDir` iterator is exhausted. Instead we check if the underlying `ReadDir` iterator actually has an entry and return `None` if the iterator is exhausted to indicate to the caller of `DevNodesBlocking::next()` that the iterator has been exhausted.