### PR TITLE
device_mut needs a mutable reference of self and remove unused import

### DIFF
--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -762,7 +762,7 @@ mod tokio_stream {
         }
 
         /// Returns a mutable reference to the underlying device
-        pub fn device_mut(&self) -> &mut Device {
+        pub fn device_mut(&mut self) -> &mut Device {
             self.device.get_mut()
         }
 

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -642,6 +642,4 @@ mod tokio_stream {
     }
 }
 #[cfg(feature = "tokio")]
-pub(crate) use tokio_stream::poll_fn;
-#[cfg(feature = "tokio")]
 pub use tokio_stream::VirtualEventStream;


### PR DESCRIPTION
- `EventStream::device_mut()` needs a mutable reference to `self`.
- Remove an unused import in `src/uinput.rs`.