### PR TITLE
Create GH actions builder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,28 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Format
+      run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Doc
+      run: cargo doc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,6 @@
 //! For demonstrations of how to use this library in blocking, nonblocking, and async (tokio) modes,
 //! please reference the "examples" directory.
 
-#![deny(warnings)]
 // should really be cfg(target_os = "linux") and maybe also android?
 #![cfg(unix)]
 


### PR DESCRIPTION
There exists what looks like a stale Travis CI manifest, but nothing is using it. Let's use GH Actions to make sure PRs build cleanly with standard formatting, and pass tests.