### PR TITLE
avoid loop in DevNodes::next_entry() and return Ok(None) when exhausted

### DIFF
--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -352,7 +352,7 @@ impl Iterator for DevNodesBlocking {
     type Item = io::Result<PathBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(entry) = self.dir.next() {
+        for entry in self.dir.by_ref() {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(e) => return Some(Err(e)),

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -388,7 +388,7 @@ impl DevNodes {
                 continue;
             }
 
-            return entry.path();
+            return Ok(Some(entry.path()));
         }
 
         Ok(None)


### PR DESCRIPTION
This PR is similar to #79 but for the asynchronous variant `DevNodes` instead. Basically, `next_entry()` is rewritten such that when the underlying `next_entry()` is exhausted, it returns `Ok(None)` to indicate that the iterator has been exhausted.