### PR TITLE
examples: show the device path of the virtual device

### DIFF
--- a/examples/virtual_ff.rs
+++ b/examples/virtual_ff.rs
@@ -13,6 +13,11 @@ fn main() -> Result<(), Error> {
         .with_ff_effects_max(16)
         .build()?;
 
+    for path in device.enumerate_dev_nodes_blocking()? {
+        let path = path?;
+        println!("Available as {}", path.display());
+    }
+
     let mut ids: BTreeSet<u16> = (0..16).into_iter().collect();
 
     println!("Waiting for Ctrl-C...");

--- a/examples/virtual_joystick.rs
+++ b/examples/virtual_joystick.rs
@@ -17,6 +17,11 @@ fn main() -> std::io::Result<()> {
         .build()
         .unwrap();
 
+    for path in device.enumerate_dev_nodes_blocking()? {
+        let path = path?;
+        println!("Available as {}", path.display());
+    }
+
     let type_ = EventType::ABSOLUTE;
     // Hopefully you don't have ABS_X bound to anything important.
     let code = AbsoluteAxisType::ABS_X.0;

--- a/examples/virtual_keyboard.rs
+++ b/examples/virtual_keyboard.rs
@@ -15,6 +15,11 @@ fn main() -> std::io::Result<()> {
         .build()
         .unwrap();
 
+    for path in device.enumerate_dev_nodes_blocking()? {
+        let path = path?;
+        println!("Available as {}", path.display());
+    }
+
     let type_ = EventType::KEY;
     // Note this will ACTUALLY PRESS the button on your computer.
     // Hopefully you don't have BTN_DPAD_UP bound to anything important.


### PR DESCRIPTION
This PR extends the virtual device examples to use the `enumerate_dev_nodes_blocking()` function to show the path of the virtual device, such that you don't have to guess the path when trying to test the examples with tools such as `evtest` and `fftest`.