### PR TITLE
Document items behind feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ itertools = "0.10"
 [[example]]
 name = "evtest_tokio"
 required-features = ["tokio"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,14 @@
 
 // should really be cfg(target_os = "linux") and maybe also android?
 #![cfg(unix)]
+// Flag items' docs' with their required feature flags, but only on docsrs so
+// that local docs can still be built on stable toolchains.
+// As of the time of writing, the stabilization plan is such that:
+// - Once stabilized, this attribute should be replaced with #![doc(auto_cfg)]
+// - Then in edition 2024, doc(auto_cfg) will become the default and the
+//   attribute can be removed entirely
+// (see https://github.com/rust-lang/rust/pull/100883#issuecomment-1264470491)
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 // has to be first for its macro
 #[macro_use]

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -814,7 +814,7 @@ mod tokio_stream {
     ///
     /// This can be used by calling [`stream.next_event().await?`](Self::next_event), or if you
     /// need to pass it as a stream somewhere, the [`futures::Stream`](Stream) implementation.
-    /// There's also a lower-level [`poll_event`] function if you need to fetch an event from
+    /// There's also a lower-level [`Self::poll_event`] function if you need to fetch an event from
     /// inside a `Future::poll` impl.
     pub struct EventStream {
         device: AsyncFd<RawDevice>,

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -739,7 +739,7 @@ mod tokio_stream {
     ///
     /// This can be used by calling [`stream.next_event().await?`](Self::next_event), or if you
     /// need to pass it as a stream somewhere, the [`futures::Stream`](Stream) implementation.
-    /// There's also a lower-level [`poll_event`] function if you need to fetch an event from
+    /// There's also a lower-level [`Self::poll_event`] function if you need to fetch an event from
     /// inside a `Future::poll` impl.
     pub struct EventStream {
         device: AsyncFd<Device>,

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -537,7 +537,7 @@ mod tokio_stream {
     ///
     /// This can be used by calling [`stream.next_event().await?`](Self::next_event), or if you
     /// need to pass it as a stream somewhere, the [`futures::Stream`](Stream) implementation.
-    /// There's also a lower-level [`poll_event`] function if you need to fetch an event from
+    /// There's also a lower-level [`Self::poll_event`] function if you need to fetch an event from
     /// inside a `Future::poll` impl.
     pub struct VirtualEventStream {
         device: AsyncFd<VirtualDevice>,


### PR DESCRIPTION
Should cause `docs.rs` to build documentation for items behind feature flags, and to label them with the associated feature flags.

Uses the [`--all-features`](https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options) cargo option and the unstable [`doc_auto_cfg`](https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg) feature to achieve this. Places the `doc_auto_cfg` feature behind a cfg flag so that it's only used when running on `docs.rs`.

Includes a plan accounting for the [(currently) expected stabilization path for `doc_auto_cfg`](https://github.com/rust-lang/rust/pull/100883).

Unfortunately, I lack the setup required to run `docs.rs` locally, so I cannot test the `docs.rs`-specific configuration options at this time. I understand that may make this PR not very useful. For what it's worth, the configuration options are based on those used by [`tokio`](https://github.com/tokio-rs/tokio/blob/992a16812258bae5192a997484ada046a88a6425/tokio/Cargo.toml#L167-L173).

Sorry about the lack of testing; I just thought this was an interesting problem, went and read about it, and am offering this code containing what I learned, in case it is of any use.

Under this PR, docs can be built locally with `cargo doc` as usual, but observing the new features requires instead using `cargo +nightly rustdoc --all-features -- --cfg docsrs`.

Stable alternatives include just running `cargo doc` with `--all-features`; however, the docs produced this way do not indicate which items require feature flags.

Closes #102.