### PR TITLE
derive Hash, Eq, PartialEq from InputId

### DIFF
--- a/src/inputid.rs
+++ b/src/inputid.rs
@@ -1,7 +1,7 @@
 use crate::compat::input_id;
 use std::fmt;
 
-#[derive(Clone)]
+#[derive(Clone, Hash, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct InputId(pub(crate) input_id);
 


### PR DESCRIPTION
Many modern peripherals create multiple `/dev/input/eventXX` files, which all share the same product and vendor id. 
I want to group all `Device`s from the same physical device and store different physical devices in a HashMap.

```rust
let mut device_map: HashMap<InputId, Vec<Device>> = HashMap::new();
for device in evdev::enumerate().map(|t| t.1) {
    let value = device_map.entry(device.input_id()).or_insert(Vec::new());
    value.push(device);   
}
```
