### PR TITLE
implement Device::get_absinfo()

### DIFF
--- a/examples/blink_keyboard_leds.rs
+++ b/examples/blink_keyboard_leds.rs
@@ -4,7 +4,7 @@ mod _pick_device;
 
 fn main() {
     let mut d = _pick_device::pick_device();
-    println!("{}", d);
+    println!("{d}");
     println!("Blinking the Keyboard LEDS...");
     for i in 0..5 {
         let on = i % 2 != 0;

--- a/examples/evtest.rs
+++ b/examples/evtest.rs
@@ -5,11 +5,11 @@ mod _pick_device;
 
 fn main() {
     let mut d = _pick_device::pick_device();
-    println!("{}", d);
+    println!("{d}");
     println!("Events:");
     loop {
         for ev in d.fetch_events().unwrap() {
-            println!("{:?}", ev);
+            println!("{ev:?}");
         }
     }
 }

--- a/examples/evtest_nonblocking.rs
+++ b/examples/evtest_nonblocking.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::os::unix::io::AsRawFd;
 
     let mut d = _pick_device::pick_device();
-    println!("{}", d);
+    println!("{d}");
 
     let raw_fd = d.as_raw_fd();
     // Set nonblocking
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match d.fetch_events() {
             Ok(iterator) => {
                 for ev in iterator {
-                    println!("{:?}", ev);
+                    println!("{ev:?}");
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 epoll::epoll_wait(epoll_fd.as_raw_fd(), &mut events, -1)?;
             }
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 break;
             }
         }

--- a/examples/force_feedback.rs
+++ b/examples/force_feedback.rs
@@ -4,7 +4,7 @@ mod _pick_device;
 
 fn main() -> std::io::Result<()> {
     let mut d = _pick_device::pick_device();
-    println!("{}", d);
+    println!("{d}");
     println!("It's time to rumble!");
 
     let effect_data = FFEffectData {

--- a/examples/virtual_ff.rs
+++ b/examples/virtual_ff.rs
@@ -32,10 +32,10 @@ fn main() -> Result<(), Error> {
 
                     match value {
                         FFStatus::FF_STATUS_STOPPED => {
-                            println!("stopped effect ID = {}", effect_id);
+                            println!("stopped effect ID = {effect_id}");
                         }
                         FFStatus::FF_STATUS_PLAYING => {
-                            println!("playing effect ID = {}", effect_id);
+                            println!("playing effect ID = {effect_id}");
                         }
                         _ => (),
                     }
@@ -43,7 +43,7 @@ fn main() -> Result<(), Error> {
                     continue;
                 }
                 kind => {
-                    println!("event kind = {:?}", kind);
+                    println!("event kind = {kind:?}");
                     continue;
                 }
             };

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -5,7 +5,6 @@ use crate::raw_stream::{FFEffect, RawDevice};
 use crate::{constants::*, AbsInfo};
 use crate::{AttributeSet, AttributeSetRef, AutoRepeat, InputEvent, InputEventKind, InputId, Key};
 
-
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::time::SystemTime;

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -277,13 +277,10 @@ impl Device {
     }
 
     /// Get the AbsInfo for each supported AbsoluteAxis
-    pub fn get_absinfo(&self) -> io::Result<impl Iterator<Item = (AbsoluteAxisType, AbsInfo)> + '_> {
-        let raw_absinfo = self.get_abs_state()?;
-        Ok(self
-            .supported_absolute_axes()
-            .into_iter()
-            .flat_map(AttributeSetRef::iter)
-            .map(move |axes| (axes, AbsInfo(raw_absinfo[axes.0 as usize]))))
+    pub fn get_absinfo(
+        &self,
+    ) -> io::Result<impl Iterator<Item = (AbsoluteAxisType, AbsInfo)> + '_> {
+        self.raw.get_absinfo()
     }
 
     /// Retrieve the current switch state directly via kernel syscall.

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -622,12 +622,12 @@ impl fmt::Display for Device {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "{}:", self.name().unwrap_or("Unnamed device"))?;
         let (maj, min, pat) = self.driver_version();
-        writeln!(f, "  Driver version: {}.{}.{}", maj, min, pat)?;
+        writeln!(f, "  Driver version: {maj}.{min}.{pat}")?;
         if let Some(ref phys) = self.physical_path() {
-            writeln!(f, "  Physical address: {:?}", phys)?;
+            writeln!(f, "  Physical address: {phys:?}")?;
         }
         if let Some(ref uniq) = self.unique_name() {
-            writeln!(f, "  Unique name: {:?}", uniq)?;
+            writeln!(f, "  Unique name: {uniq:?}")?;
         }
 
         let id = self.input_id();
@@ -659,7 +659,7 @@ impl fmt::Display for Device {
         }
 
         if let Some(supported_relative) = self.supported_relative_axes() {
-            writeln!(f, "  Relative Axes: {:?}", supported_relative)?;
+            writeln!(f, "  Relative Axes: {supported_relative:?}")?;
         }
 
         if let (Some(supported_abs), Some(abs_vals)) =
@@ -676,7 +676,7 @@ impl fmt::Display for Device {
         }
 
         if let Some(supported_misc) = self.misc_properties() {
-            writeln!(f, "  Miscellaneous capabilities: {:?}", supported_misc)?;
+            writeln!(f, "  Miscellaneous capabilities: {supported_misc:?}")?;
         }
 
         if let (Some(supported_switch), Some(switch_vals)) =

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -277,16 +277,12 @@ impl Device {
     }
 
     /// Get the AbsInfo for each supported AbsoluteAxis
-    pub fn get_absinfo(&self) -> io::Result<impl Iterator<Item = (AbsoluteAxisType, AbsInfo)>> {
+    pub fn get_absinfo(&self) -> io::Result<impl Iterator<Item = (AbsoluteAxisType, AbsInfo)> + '_> {
         let raw_absinfo = self.get_abs_state()?;
-        let supported_axis: Vec<_> = self
+        Ok(self
             .supported_absolute_axes()
-            .unwrap_or(&AttributeSet::new())
-            .iter()
-            .collect();
-
-        Ok(supported_axis
             .into_iter()
+            .flat_map(AttributeSetRef::iter)
             .map(move |axes| (axes, AbsInfo(raw_absinfo[axes.0 as usize]))))
     }
 

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -4,7 +4,8 @@ use crate::ff::*;
 use crate::raw_stream::{FFEffect, RawDevice};
 use crate::{constants::*, AbsInfo};
 use crate::{AttributeSet, AttributeSetRef, AutoRepeat, InputEvent, InputEventKind, InputId, Key};
-use std::collections::HashMap;
+
+
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::time::SystemTime;
@@ -277,14 +278,17 @@ impl Device {
     }
 
     /// Get the AbsInfo for each supported AbsoluteAxis
-    pub fn get_absinfo(&self) -> io::Result<HashMap<AbsoluteAxisType, AbsInfo>> {
+    pub fn get_absinfo(&self) -> io::Result<impl Iterator<Item = (AbsoluteAxisType, AbsInfo)>> {
         let raw_absinfo = self.get_abs_state()?;
-        Ok(self
+        let supported_axis: Vec<_> = self
             .supported_absolute_axes()
             .unwrap_or(&AttributeSet::new())
             .iter()
-            .map(|axis| (axis, AbsInfo(raw_absinfo[axis.0 as usize])))
-            .collect())
+            .collect();
+
+        Ok(supported_axis
+            .into_iter()
+            .map(move |axes| (axes, AbsInfo(raw_absinfo[axes.0 as usize]))))
     }
 
     /// Retrieve the current switch state directly via kernel syscall.

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -1,9 +1,10 @@
 use crate::compat::{input_absinfo, input_event};
-use crate::constants::*;
 use crate::device_state::DeviceState;
 use crate::ff::*;
 use crate::raw_stream::{FFEffect, RawDevice};
+use crate::{constants::*, AbsInfo};
 use crate::{AttributeSet, AttributeSetRef, AutoRepeat, InputEvent, InputEventKind, InputId, Key};
+use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::time::SystemTime;
@@ -273,6 +274,17 @@ impl Device {
     /// Retrieve the current absolute axis state directly via kernel syscall.
     pub fn get_abs_state(&self) -> io::Result<[input_absinfo; AbsoluteAxisType::COUNT]> {
         self.raw.get_abs_state()
+    }
+
+    /// Get the AbsInfo for each supported AbsoluteAxis
+    pub fn get_absinfo(&self) -> io::Result<HashMap<AbsoluteAxisType, AbsInfo>> {
+        let raw_absinfo = self.get_abs_state()?;
+        Ok(self
+            .supported_absolute_axes()
+            .unwrap_or(&AttributeSet::new())
+            .iter()
+            .map(|axis| (axis, AbsInfo(raw_absinfo[axis.0 as usize])))
+            .collect())
     }
 
     /// Retrieve the current switch state directly via kernel syscall.


### PR DESCRIPTION
Currently there is no way to get a `AbsInfo` object from the library. Sure, there is the `get_abs_state()` method, but that only returns a slice of `[input_absinfo,_]` and it is not at all clear that one needs to index that slice with the correct code (i.e. ABS_X) to get the corresponding absinfo.

Current API:
```rust
let code = AbsoluteAxisType::ABS_X.0 as usize;
let raw_absinfo = device.get_abs_state()?;
let absinfo = AbsInof::new(
    raw_absinfo[code].value,
    raw_absinfo[code].minimum,
    raw_absinfo[code].maximum,
    raw_absinfo[code].fuzz,
    raw_absinfo[code].flat,
    raw_absinfo[code].resolution,
);
// be aware: we get a valid absinfo, even if the device does not support 
// AbsoluteAxisType::ABS_X, or does not support EV_ABS
```

Proposed API:
```rust
let absinfo = device
    .get_absinfo()
    .unwrap()
    .get(&AbsoluteAxisType::ABS_X)
    .unwrap(); // this fails if ABS_X or EV_ABS is not supported
```