### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `evdev`
 =======
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/emberian/evdev/Rust)](https://github.com/emberian/evdev/actions/workflows/rust.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/emberian/evdev/rust.yml?branch=master)](https://github.com/emberian/evdev/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/evdev.svg?style=flat-square)](https://crates.io/crates/evdev)
 
 [Documentation](https://docs.rs/evdev)


### PR DESCRIPTION
The build badge at the top of the README became unavailable/broken due to https://github.com/badges/shields/issues/8671.

Having a working, especially "green"/successful build badge also makes a way better impression on visitors of the project than a broken one.