### PR TITLE
update test_virtual_device_actually_emits to use KEY_ESC

### DIFF
--- a/tests/virtual_device.rs
+++ b/tests/virtual_device.rs
@@ -33,7 +33,7 @@ async fn test_virtual_device_actually_emits() -> Result<(), Box<dyn Error>> {
     let listen_device = maybe_device.unwrap();
 
     let type_ = EventType::KEY;
-    let code = Key::BTN_DPAD_UP.code();
+    let code = Key::KEY_ESC.code();
 
     // listen for events on the listen device
     let listener = tokio::spawn(async move {


### PR DESCRIPTION
Previously the test used BTN_DPAD_UP as a test code but the virtual device is configured to only have the KEY_ESC code. This causes the test to fail on some systems.