### PR TITLE
Fix the set_phys ioctl binding and add physical path support to the VirtualDeviceBuilder

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -86,7 +86,7 @@ ioctl_write_int!(ui_set_mscbit, UINPUT_IOCTL_BASE, 104);
 ioctl_write_int!(ui_set_ledbit, UINPUT_IOCTL_BASE, 105);
 ioctl_write_int!(ui_set_sndbit, UINPUT_IOCTL_BASE, 106);
 ioctl_write_int!(ui_set_ffbit, UINPUT_IOCTL_BASE, 107);
-ioctl_write_buf!(ui_set_phys, UINPUT_IOCTL_BASE, 108, u8);
+ioctl_write_ptr!(ui_set_phys, UINPUT_IOCTL_BASE, 108, usize);
 ioctl_write_int!(ui_set_swbit, UINPUT_IOCTL_BASE, 109);
 ioctl_write_int!(ui_set_propbit, UINPUT_IOCTL_BASE, 110);
 

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -9,6 +9,7 @@ use crate::{
     sys, AttributeSetRef, Error, FFEffectCode, InputEvent, KeyCode, MiscCode, PropType,
     RelativeAxisCode, SwitchCode, SynchronizationEvent, UInputCode, UInputEvent, UinputAbsSetup,
 };
+use std::ffi::CString;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::path::PathBuf;
 use std::{fs, io};
@@ -50,6 +51,14 @@ impl<'a> VirtualDeviceBuilder<'a> {
     pub fn input_id(mut self, id: InputId) -> Self {
         self.id = Some(id.0);
         self
+    }
+
+    pub fn with_phys(self, path: &str) -> io::Result<Self> {
+        let c_str = CString::new(path)?;
+        unsafe {
+            sys::ui_set_phys(self.fd.as_raw_fd(), c_str.as_ptr() as *const usize)?;
+        }
+        Ok(self)
     }
 
     pub fn with_keys(self, keys: &AttributeSetRef<KeyCode>) -> io::Result<Self> {


### PR DESCRIPTION
fixes the ui_set_phys ioctl binding in sys.rs  and adds a with_phys method to VirtualDeviceBuilder in uinput.rs.
The ioctl for set_phys is regrettably a bit weird. Whilst it expects to receive a pointer to a c string, it doesn't want the length of this string, but rather the size of the pointer itself.
A simple pointer cast is the cleanest workaround for this issue that I know of.
Setting the physical path of a virtual device is a pretty niche application, but can be extremely useful.