### PR TITLE
Make Device::from_fd() public

### DIFF
--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -159,7 +159,7 @@ impl RawDevice {
         Self::from_fd(fd)
     }
 
-    fn from_fd(fd: OwnedFd) -> io::Result<RawDevice> {
+    pub fn from_fd(fd: OwnedFd) -> io::Result<RawDevice> {
         let ty = {
             let mut ty = AttributeSet::<EventType>::new();
             unsafe { sys::eviocgbit_type(fd.as_raw_fd(), ty.as_mut_raw_slice())? };

--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use std::fs::File;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::path::Path;
 use std::time::SystemTime;
 use std::{fmt, io};
@@ -39,6 +39,12 @@ impl Device {
     #[inline(always)]
     pub fn open(path: impl AsRef<Path>) -> io::Result<Device> {
         Self::_open(path.as_ref())
+    }
+
+    /// Opens a device, given an already opened file descriptor.
+    #[inline(always)]
+    pub fn from_fd(fd: OwnedFd) -> io::Result<Device> {
+        RawDevice::from_fd(fd).map(Self::from_raw_device)
     }
 
     #[inline]


### PR DESCRIPTION
In some use-cases the process initializing the evdev device doesn't have the permissions to open the file - instead the fd is handed to it via e.g. DBus. This is the case for Wayland compositors using logind.

Expose Device::from_fd() as public function so we can initialize a device purely from the fd.