### PR TITLE
Revert "use entry.path() and simplify starts_with() code"

### DIFF
--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -16,6 +16,7 @@ use std::{fs, io};
 
 const UINPUT_PATH: &str = "/dev/uinput";
 const SYSFS_PATH: &str = "/sys/devices/virtual/input";
+const DEV_PATH: &str = "/dev/input";
 
 #[derive(Debug)]
 pub struct VirtualDeviceBuilder<'a> {
@@ -396,12 +397,19 @@ impl Iterator for DevNodesBlocking {
                 Err(e) => return Some(Err(e)),
             };
 
+            // Map the directory name to its file name.
+            let name = entry.file_name().to_string_lossy().to_owned().to_string();
+
             // Ignore file names that do not start with event.
-            if !entry.file_name().to_string_lossy().starts_with("event") {
+            if !name.starts_with("event") {
                 continue;
             }
 
-            return Some(Ok(entry.path()));
+            // Construct the path of the form '/dev/input/eventX'.
+            let mut path: PathBuf = PathBuf::from(DEV_PATH);
+            path.push(name);
+
+            return Some(Ok(path));
         }
 
         None
@@ -421,12 +429,19 @@ impl DevNodes {
     /// Returns the next entry in the set of device nodes.
     pub async fn next_entry(&mut self) -> io::Result<Option<PathBuf>> {
         while let Some(entry) = self.dir.next_entry().await? {
+            // Map the directory name to its file name.
+            let name = entry.file_name().to_string_lossy().to_owned().to_string();
+
             // Ignore file names that do not start with event.
-            if !entry.file_name().to_string_lossy().starts_with("event") {
+            if !name.starts_with("event") {
                 continue;
             }
 
-            return Ok(Some(entry.path()));
+            // Construct the path of the form '/dev/input/eventX'.
+            let mut path: PathBuf = PathBuf::from(DEV_PATH);
+            path.push(name);
+
+            return Ok(Some(path));
         }
 
         Ok(None)


### PR DESCRIPTION
This reverts commit d0231e3c626316b18de59eec5d1ff8a344d94c9e.

resolves device pathname regression, issue #129