### PR TITLE
Squash ENODEV in Device::Drop

### DIFF
--- a/src/sync_stream.rs
+++ b/src/sync_stream.rs
@@ -8,6 +8,7 @@ use crate::{
     InputId, KeyCode,
 };
 
+use libc::ENODEV;
 use nix::fcntl;
 use std::fs::File;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
@@ -418,7 +419,16 @@ impl Device {
 impl Drop for Device {
     fn drop(&mut self) {
         if let Err(error) = self.ungrab() {
-            eprintln!("Failed to ungrab device: {error}");
+            // Ignore when the device has already been closed
+            // by some external event like device disconnect.
+            let enodev = error
+                .raw_os_error()
+                .map(|errno| errno == ENODEV)
+                .unwrap_or_default();
+
+            if !enodev {
+                eprintln!("Failed to ungrab device: {error}");
+            }
         }
     }
 }


### PR DESCRIPTION
Device::Drop ungrabs the device, and prints a message in case of error. The problem is that ungrabbing a device that has already been disconnected will result in an `ENODEV`. There is not much point in this error message, because the device must have been ungrabbed if it doesn't exist any more.

This PR avoids printing the error message when the error is ENODEV.