### PR TITLE
Replace depreciated function in example

### DIFF
--- a/examples/virtual_keyboard.rs
+++ b/examples/virtual_keyboard.rs
@@ -33,7 +33,7 @@ fn main() -> std::io::Result<()> {
         println!("Pressed.");
         sleep(Duration::from_secs(2));
 
-        // alternativeley we can create a InputEvent, which will be any variant of InputEvent
+        // alternatively we can create a InputEvent, which will be any variant of InputEvent
         // depending on the type_ value
         let up_event = InputEvent::new(EventType::KEY.0, code, 0);
         device.emit(&[up_event]).unwrap();

--- a/examples/virtual_touch_screen.rs
+++ b/examples/virtual_touch_screen.rs
@@ -1,12 +1,10 @@
-use evdev::{
-    uinput::VirtualDeviceBuilder, AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent,
-};
+use evdev::uinput::VirtualDevice;
+use evdev::{AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent};
 use evdev::{KeyCode, KeyEvent, UinputAbsSetup};
 use std::thread::sleep;
 use std::time::Duration;
 
 fn main() -> std::io::Result<()> {
-
     // Size of the touch screen
     let max_x = 1080;
     let max_y = 1920;
@@ -18,7 +16,7 @@ fn main() -> std::io::Result<()> {
     let mut buttons = AttributeSet::<KeyCode>::new();
     buttons.insert(KeyCode::BTN_TOUCH);
 
-    let mut device = VirtualDeviceBuilder::new()?
+    let mut device = VirtualDevice::builder()?
         .name("Fake TouchScreen")
         .with_keys(&buttons)?
         .with_absolute_axis(&UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, abs_setup_x))?

--- a/examples/virtual_touch_screen.rs
+++ b/examples/virtual_touch_screen.rs
@@ -1,8 +1,11 @@
-use evdev::uinput::VirtualDevice;
-use evdev::{AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent};
-use evdev::{KeyCode, KeyEvent, UinputAbsSetup};
-use std::thread::sleep;
-use std::time::Duration;
+use evdev::{
+    uinput::VirtualDevice,
+    {
+        AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent, KeyCode, KeyEvent,
+        UinputAbsSetup,
+    },
+};
+use std::{thread::sleep, time::Duration};
 
 fn main() -> std::io::Result<()> {
     // Size of the touch screen


### PR DESCRIPTION
Thanks for the great library, was looking at the examples and noticed the deprecation so just did a quick replace as per the suggestion.