### PR TITLE
Gracefully handle missing ioctl on kernel 2.6.x

### DIFF
--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -139,9 +139,16 @@ impl RawDevice {
 
         let props = {
             let mut props = AttributeSet::<PropType>::new();
-            unsafe { sys::eviocgprop(fd.as_raw_fd(), props.as_mut_raw_slice())? };
-            props
-        }; // FIXME: handle old kernel
+
+            match unsafe { sys::eviocgprop(fd.as_raw_fd(), props.as_mut_raw_slice()) } {
+                Ok(_) => props,
+
+                // Kernel 2.6.x does not implement this ioctl, return empty props
+                Err(e) if e == nix::errno::Errno::EINVAL => props,
+
+                Err(e) => return Err(e.into())
+            }
+        };
 
         let supported_keys = if ty.contains(EventType::KEY) {
             let mut keys = AttributeSet::<KeyCode>::new();

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -146,7 +146,7 @@ impl RawDevice {
                 // Kernel 2.6.x does not implement this ioctl, return empty props
                 Err(e) if e == nix::errno::Errno::EINVAL => props,
 
-                Err(e) => return Err(e.into())
+                Err(e) => return Err(e.into()),
             }
         };
 

--- a/src/raw_stream.rs
+++ b/src/raw_stream.rs
@@ -144,7 +144,7 @@ impl RawDevice {
                 Ok(_) => props,
 
                 // Kernel 2.6.x does not implement this ioctl, return empty props
-                Err(e) if e == nix::errno::Errno::EINVAL => props,
+                Err(nix::errno::Errno::EINVAL) => props,
 
                 Err(e) => return Err(e.into()),
             }


### PR DESCRIPTION
Running on Linux 2.6.37 the `Device::open()` function returns error:

> Error: Invalid argument (os error 22)

This change simply checks for the invalid argument error code from `eviocgprop` call and returns the empty props.