### PR TITLE
feat: add BTN_GRIPL/GRIPR/GRIPL2/GRIPR2 (Steam Deck back paddles)

### DIFF
--- a/src/scancodes.rs
+++ b/src/scancodes.rs
@@ -497,6 +497,10 @@ evdev_enum!(
     BTN_DPAD_DOWN = 0x221,
     BTN_DPAD_LEFT = 0x222,
     BTN_DPAD_RIGHT = 0x223,
+    BTN_GRIPL = 0x224,
+    BTN_GRIPR = 0x225,
+    BTN_GRIPL2 = 0x226,
+    BTN_GRIPR2 = 0x227,
     KEY_ALS_TOGGLE = 0x230,   /* Ambient light sensor */
     KEY_BUTTONCONFIG = 0x240, /* AL Button Configuration */
     KEY_TASKMANAGER = 0x241,  /* AL Task/Project Manager */


### PR DESCRIPTION
## Summary

Adds four button codes for the Steam Deck's back paddle buttons that are defined in the Linux kernel's `input-event-codes.h` but missing from this crate:

```
BTN_GRIPL  = 0x224  // back paddle L5 (top left)
BTN_GRIPR  = 0x225  // back paddle R5 (top right)
BTN_GRIPL2 = 0x226  // back paddle L4 (bottom left)
BTN_GRIPR2 = 0x227  // back paddle R4 (bottom right)
```

These are emitted by the `hid-steam` kernel driver for the Steam Deck hardware. Without them, any application using this crate cannot handle back paddle input by name — `Key::from_str("BTN_GRIPL")` silently fails.

## Verification

The names and codes match the official kernel header exactly:
```c
// include/uapi/linux/input-event-codes.h
#define BTN_GRIPL   0x224
#define BTN_GRIPR   0x225
#define BTN_GRIPL2  0x226
#define BTN_GRIPR2  0x227
```